### PR TITLE
Convert fuma frontend html to blade with active interactions

### DIFF
--- a/app/Http/Controllers/FumaController.php
+++ b/app/Http/Controllers/FumaController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tournament;
+use App\Models\Team;
+use App\Models\Player;
+use App\Models\MatchModel;
+use Illuminate\Http\Request;
+
+class FumaController extends Controller
+{
+    public function index()
+    {
+        // Get statistics for the dashboard
+        $stats = [
+            'active_tournaments' => Tournament::where('status', 'ongoing')->count(),
+            'total_teams' => Team::count(),
+            'total_players' => Player::count(),
+            'total_matches' => MatchModel::where('status', 'completed')->count(),
+        ];
+
+        // Get featured content
+        $featured_tournaments = Tournament::with(['teams', 'organizer'])
+            ->where('status', 'ongoing')
+            ->orWhere('status', 'upcoming')
+            ->orderBy('start_date', 'asc')
+            ->limit(6)
+            ->get();
+
+        $top_teams = Team::with(['players'])
+            ->orderBy('rating', 'desc')
+            ->limit(8)
+            ->get();
+
+        $upcoming_matches = MatchModel::with(['homeTeam', 'awayTeam', 'tournament'])
+            ->where('status', 'scheduled')
+            ->where('scheduled_at', '>', now())
+            ->orderBy('scheduled_at', 'asc')
+            ->limit(6)
+            ->get();
+
+        $top_players = Player::with(['team'])
+            ->orderBy('rating', 'desc')
+            ->limit(8)
+            ->get();
+
+        return view('fuma.index', compact(
+            'stats',
+            'featured_tournaments',
+            'top_teams',
+            'upcoming_matches',
+            'top_players'
+        ));
+    }
+}

--- a/app/Http/Controllers/FumaMatchController.php
+++ b/app/Http/Controllers/FumaMatchController.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MatchModel;
+use App\Models\Tournament;
+use App\Models\Team;
+use Illuminate\Http\Request;
+
+class FumaMatchController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = MatchModel::with(['homeTeam', 'awayTeam', 'tournament']);
+
+        // Apply filters
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+
+        if ($request->filled('tournament')) {
+            $query->where('tournament_id', $request->tournament);
+        }
+
+        if ($request->filled('date')) {
+            $query->whereDate('scheduled_at', $request->date);
+        }
+
+        $matches = $query->orderBy('scheduled_at', 'desc')->paginate(10);
+
+        // Get tournaments for filter dropdown
+        $tournaments = Tournament::orderBy('name')->get();
+
+        return view('fuma.matches.index', compact('matches', 'tournaments'));
+    }
+
+    public function show(MatchModel $match)
+    {
+        $match->load([
+            'homeTeam.players',
+            'awayTeam.players',
+            'tournament',
+            'events.player'
+        ]);
+
+        return view('fuma.matches.show', compact('match'));
+    }
+
+    public function create()
+    {
+        $tournaments = Tournament::where('status', '!=', 'completed')->orderBy('name')->get();
+        $teams = Team::orderBy('name')->get();
+
+        return view('fuma.matches.create', compact('tournaments', 'teams'));
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'tournament_id' => 'required|exists:tournaments,id',
+            'home_team_id' => 'required|exists:teams,id',
+            'away_team_id' => 'required|exists:teams,id|different:home_team_id',
+            'stage' => 'required|in:group,round_of_16,quarter_final,semi_final,final',
+            'scheduled_at' => 'required|date|after:now',
+            'venue' => 'nullable|string|max:255',
+            'notes' => 'nullable|string',
+        ]);
+
+        $validated['status'] = 'scheduled';
+
+        $match = MatchModel::create($validated);
+
+        return redirect()->route('fuma.matches.show', $match)
+            ->with('success', 'Match scheduled successfully!');
+    }
+
+    public function updateScore(Request $request, MatchModel $match)
+    {
+        $validated = $request->validate([
+            'home_score' => 'required|integer|min:0',
+            'away_score' => 'required|integer|min:0',
+            'status' => 'required|in:live,completed',
+        ]);
+
+        $match->update($validated);
+
+        // Update team statistics if match is completed
+        if ($validated['status'] === 'completed') {
+            $this->updateTeamStats($match);
+        }
+
+        return redirect()->route('fuma.matches.show', $match)
+            ->with('success', 'Match score updated successfully!');
+    }
+
+    private function updateTeamStats(MatchModel $match)
+    {
+        $tournament = $match->tournament;
+        $homeTeam = $match->homeTeam;
+        $awayTeam = $match->awayTeam;
+
+        // Get pivot records
+        $homePivot = $tournament->teams()->where('team_id', $homeTeam->id)->first()->pivot;
+        $awayPivot = $tournament->teams()->where('team_id', $awayTeam->id)->first()->pivot;
+
+        // Update match count
+        $homePivot->matches_played += 1;
+        $awayPivot->matches_played += 1;
+
+        // Update goals
+        $homePivot->goals_for += $match->home_score;
+        $homePivot->goals_against += $match->away_score;
+        $awayPivot->goals_for += $match->away_score;
+        $awayPivot->goals_against += $match->home_score;
+
+        // Determine winner and update stats
+        if ($match->home_score > $match->away_score) {
+            // Home team wins
+            $homePivot->wins += 1;
+            $homePivot->points += 3;
+            $awayPivot->losses += 1;
+        } elseif ($match->away_score > $match->home_score) {
+            // Away team wins
+            $awayPivot->wins += 1;
+            $awayPivot->points += 3;
+            $homePivot->losses += 1;
+        } else {
+            // Draw
+            $homePivot->draws += 1;
+            $homePivot->points += 1;
+            $awayPivot->draws += 1;
+            $awayPivot->points += 1;
+        }
+
+        // Update goal difference
+        $homePivot->goal_difference = $homePivot->goals_for - $homePivot->goals_against;
+        $awayPivot->goal_difference = $awayPivot->goals_for - $awayPivot->goals_against;
+
+        // Save the pivot records
+        $homePivot->save();
+        $awayPivot->save();
+    }
+}

--- a/app/Http/Controllers/FumaPlayerController.php
+++ b/app/Http/Controllers/FumaPlayerController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Player;
+use App\Models\Team;
+use Illuminate\Http\Request;
+
+class FumaPlayerController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Player::with(['team']);
+
+        // Apply filters
+        if ($request->filled('position')) {
+            $query->where('position', $request->position);
+        }
+
+        if ($request->filled('team')) {
+            $query->where('team_id', $request->team);
+        }
+
+        if ($request->filled('search')) {
+            $query->where('name', 'like', '%' . $request->search . '%');
+        }
+
+        // Apply sorting
+        $sort = $request->get('sort', 'name');
+        switch ($sort) {
+            case 'rating':
+                $query->orderBy('rating', 'desc');
+                break;
+            case 'goals':
+                $query->orderBy('goals_scored', 'desc');
+                break;
+            default:
+                $query->orderBy('name', 'asc');
+                break;
+        }
+
+        $players = $query->paginate(16);
+
+        // Get teams for filter dropdown
+        $teams = Team::orderBy('name')->get();
+
+        return view('fuma.players.index', compact('players', 'teams'));
+    }
+
+    public function show(Player $player)
+    {
+        $player->load(['team', 'matchEvents']);
+
+        // Get player statistics
+        $player_stats = [
+            'matches_played' => $player->matchEvents->pluck('match_id')->unique()->count(),
+            'goals' => $player->goals_scored,
+            'assists' => $player->assists,
+            'yellow_cards' => $player->yellow_cards,
+            'red_cards' => $player->red_cards,
+            'clean_sheets' => $player->clean_sheets,
+        ];
+
+        return view('fuma.players.show', compact('player', 'player_stats'));
+    }
+
+    public function create()
+    {
+        $teams = Team::orderBy('name')->get();
+        $positions = ['Goalkeeper', 'Defender', 'Midfielder', 'Forward'];
+
+        return view('fuma.players.create', compact('teams', 'positions'));
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'position' => 'required|in:Goalkeeper,Defender,Midfielder,Forward',
+            'jersey_number' => 'nullable|string|max:3',
+            'birth_date' => 'nullable|date|before:today',
+            'nationality' => 'required|string|max:255',
+            'height' => 'nullable|numeric|min:100|max:250',
+            'weight' => 'nullable|numeric|min:40|max:150',
+            'team_id' => 'nullable|exists:teams,id',
+            'avatar' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
+        ]);
+
+        if ($request->hasFile('avatar')) {
+            $validated['avatar'] = $request->file('avatar')->store('players', 'public');
+        }
+
+        // Set default values
+        $validated['rating'] = 0.00;
+        $validated['goals_scored'] = 0;
+        $validated['assists'] = 0;
+        $validated['clean_sheets'] = 0;
+        $validated['yellow_cards'] = 0;
+        $validated['red_cards'] = 0;
+
+        $player = Player::create($validated);
+
+        return redirect()->route('fuma.players.show', $player)
+            ->with('success', 'Player added successfully!');
+    }
+}

--- a/app/Http/Controllers/FumaTeamController.php
+++ b/app/Http/Controllers/FumaTeamController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Team;
+use Illuminate\Http\Request;
+
+class FumaTeamController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Team::with(['players']);
+
+        // Apply filters
+        if ($request->filled('city')) {
+            $query->where('city', $request->city);
+        }
+
+        if ($request->filled('search')) {
+            $query->where('name', 'like', '%' . $request->search . '%');
+        }
+
+        // Apply sorting
+        $sort = $request->get('sort', 'name');
+        switch ($sort) {
+            case 'rating':
+                $query->orderBy('rating', 'desc');
+                break;
+            case 'city':
+                $query->orderBy('city', 'asc');
+                break;
+            default:
+                $query->orderBy('name', 'asc');
+                break;
+        }
+
+        $teams = $query->paginate(12);
+
+        // Get all cities for filter dropdown
+        $cities = Team::distinct()->pluck('city')->filter()->sort()->values();
+
+        return view('fuma.teams.index', compact('teams', 'cities'));
+    }
+
+    public function show(Team $team)
+    {
+        $team->load(['players', 'tournaments', 'manager']);
+
+        // Get team statistics
+        $team_stats = [
+            'total_matches' => $team->getAllMatchesAttribute()->count(),
+            'wins' => $team->tournaments->sum('pivot.wins'),
+            'draws' => $team->tournaments->sum('pivot.draws'),
+            'losses' => $team->tournaments->sum('pivot.losses'),
+            'goals_for' => $team->tournaments->sum('pivot.goals_for'),
+            'goals_against' => $team->tournaments->sum('pivot.goals_against'),
+        ];
+
+        return view('fuma.teams.show', compact('team', 'team_stats'));
+    }
+
+    public function create()
+    {
+        return view('fuma.teams.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'city' => 'required|string|max:255',
+            'country' => 'required|string|max:255',
+            'manager_name' => 'nullable|string|max:255',
+            'manager_phone' => 'nullable|string|max:20',
+            'manager_email' => 'nullable|email|max:255',
+            'logo' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
+        ]);
+
+        if ($request->hasFile('logo')) {
+            $validated['logo'] = $request->file('logo')->store('teams', 'public');
+        }
+
+        $validated['rating'] = 0.00;
+        $validated['trophies_count'] = 0;
+
+        $team = Team::create($validated);
+
+        return redirect()->route('fuma.teams.show', $team)
+            ->with('success', 'Team registered successfully!');
+    }
+}

--- a/app/Http/Controllers/FumaTournamentController.php
+++ b/app/Http/Controllers/FumaTournamentController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tournament;
+use App\Models\Team;
+use App\Models\Player;
+use Illuminate\Http\Request;
+
+class FumaTournamentController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Tournament::with(['teams', 'organizer']);
+
+        // Apply filters
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+
+        if ($request->filled('search')) {
+            $query->where('name', 'like', '%' . $request->search . '%');
+        }
+
+        if ($request->filled('date_from')) {
+            $query->where('start_date', '>=', $request->date_from);
+        }
+
+        $tournaments = $query->orderBy('start_date', 'desc')->paginate(10);
+
+        return view('fuma.tournaments.index', compact('tournaments'));
+    }
+
+    public function show(Tournament $tournament)
+    {
+        $tournament->load([
+            'teams.players',
+            'matches.homeTeam',
+            'matches.awayTeam',
+            'organizer'
+        ]);
+
+        // Get top scorers for this tournament
+        $topScorers = Player::whereHas('team.tournaments', function($query) use ($tournament) {
+                $query->where('tournament_id', $tournament->id);
+            })
+            ->orderBy('goals_scored', 'desc')
+            ->limit(5)
+            ->get();
+
+        $tournament->topScorers = $topScorers;
+
+        return view('fuma.tournaments.show', compact('tournament'));
+    }
+
+    public function create()
+    {
+        return view('fuma.tournaments.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'start_date' => 'required|date|after:today',
+            'end_date' => 'required|date|after:start_date',
+            'max_teams' => 'required|integer|min:2|max:64',
+            'venue' => 'nullable|string|max:255',
+            'logo' => 'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
+        ]);
+
+        if ($request->hasFile('logo')) {
+            $validated['logo'] = $request->file('logo')->store('tournaments', 'public');
+        }
+
+        $validated['organizer_id'] = auth()->id();
+        $validated['status'] = 'upcoming';
+
+        $tournament = Tournament::create($validated);
+
+        return redirect()->route('fuma.tournaments.show', $tournament)
+            ->with('success', 'Tournament created successfully!');
+    }
+
+    public function destroy(Tournament $tournament)
+    {
+        $tournament->delete();
+
+        return redirect()->route('fuma.tournaments.index')
+            ->with('success', 'Tournament deleted successfully!');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             ComprehensiveSeeder::class,
+            FumaSeeder::class,
         ]);
     }
 }

--- a/database/seeders/FumaSeeder.php
+++ b/database/seeders/FumaSeeder.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\Tournament;
+use App\Models\Team;
+use App\Models\Player;
+use App\Models\MatchModel;
+use App\Models\MatchEvent;
+use Carbon\Carbon;
+
+class FumaSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Create organizer user
+        $organizer = User::firstOrCreate([
+            'email' => 'organizer@fuma.com'
+        ], [
+            'name' => 'Tournament Organizer',
+            'password' => bcrypt('password'),
+            'email_verified_at' => now(),
+        ]);
+
+        // Create tournaments
+        $tournaments = [
+            [
+                'name' => 'Premier League 2023',
+                'description' => 'The premier football tournament featuring the best teams',
+                'status' => 'ongoing',
+                'start_date' => Carbon::now()->subDays(30),
+                'end_date' => Carbon::now()->addDays(60),
+                'max_teams' => 20,
+                'venue' => 'Various Stadiums',
+                'organizer_id' => $organizer->id,
+            ],
+            [
+                'name' => 'Champions Cup',
+                'description' => 'Elite knockout tournament for champion teams',
+                'status' => 'upcoming',
+                'start_date' => Carbon::now()->addDays(15),
+                'end_date' => Carbon::now()->addDays(45),
+                'max_teams' => 16,
+                'venue' => 'National Stadium',
+                'organizer_id' => $organizer->id,
+            ],
+            [
+                'name' => 'Winter Tournament',
+                'description' => 'Winter season championship',
+                'status' => 'completed',
+                'start_date' => Carbon::now()->subDays(120),
+                'end_date' => Carbon::now()->subDays(60),
+                'max_teams' => 8,
+                'venue' => 'Winter Arena',
+                'organizer_id' => $organizer->id,
+            ],
+        ];
+
+        foreach ($tournaments as $tournamentData) {
+            Tournament::firstOrCreate([
+                'name' => $tournamentData['name']
+            ], $tournamentData);
+        }
+
+        // Create teams
+        $teams = [
+            [
+                'name' => 'City FC',
+                'description' => 'Professional football club from the city',
+                'city' => 'Jakarta',
+                'country' => 'Indonesia',
+                'manager_name' => 'John Smith',
+                'manager_phone' => '+62812345678',
+                'manager_email' => 'john@cityfc.com',
+                'rating' => 4.5,
+                'trophies_count' => 3,
+            ],
+            [
+                'name' => 'United SC',
+                'description' => 'United Sports Club with rich history',
+                'city' => 'Bandung',
+                'country' => 'Indonesia',
+                'manager_name' => 'Mike Johnson',
+                'manager_phone' => '+62823456789',
+                'manager_email' => 'mike@unitedsc.com',
+                'rating' => 4.2,
+                'trophies_count' => 2,
+            ],
+            [
+                'name' => 'Dynamo FC',
+                'description' => 'Dynamic and aggressive playing style',
+                'city' => 'Surabaya',
+                'country' => 'Indonesia',
+                'manager_name' => 'Carlos Rodriguez',
+                'manager_phone' => '+62834567890',
+                'manager_email' => 'carlos@dynamofc.com',
+                'rating' => 4.0,
+                'trophies_count' => 1,
+            ],
+            [
+                'name' => 'Rovers FC',
+                'description' => 'Traditional football club with passionate fans',
+                'city' => 'Medan',
+                'country' => 'Indonesia',
+                'manager_name' => 'David Wilson',
+                'manager_phone' => '+62845678901',
+                'manager_email' => 'david@roversfc.com',
+                'rating' => 3.8,
+                'trophies_count' => 1,
+            ],
+            [
+                'name' => 'Arsenal FC',
+                'description' => 'Strong attacking team with technical players',
+                'city' => 'Yogyakarta',
+                'country' => 'Indonesia',
+                'manager_name' => 'Antonio Garcia',
+                'manager_phone' => '+62856789012',
+                'manager_email' => 'antonio@arsenalfc.com',
+                'rating' => 4.3,
+                'trophies_count' => 2,
+            ],
+            [
+                'name' => 'Lightning FC',
+                'description' => 'Fast-paced team known for quick attacks',
+                'city' => 'Semarang',
+                'country' => 'Indonesia',
+                'manager_name' => 'Roberto Silva',
+                'manager_phone' => '+62867890123',
+                'manager_email' => 'roberto@lightningfc.com',
+                'rating' => 3.9,
+                'trophies_count' => 0,
+            ],
+        ];
+
+        foreach ($teams as $teamData) {
+            Team::firstOrCreate([
+                'name' => $teamData['name']
+            ], $teamData);
+        }
+
+        // Create players
+        $playerNames = [
+            'Marcus Johnson', 'David Silva', 'Carlos Rodriguez', 'Antonio Garcia',
+            'Roberto Santos', 'Fernando Lopez', 'Miguel Torres', 'Diego Martinez',
+            'Luis Gonzalez', 'Pablo Hernandez', 'Alejandro Ruiz', 'Francisco Morales',
+            'Ricardo Vargas', 'Andres Castillo', 'Manuel Jimenez', 'Gabriel Romero',
+            'Adrian Flores', 'Sergio Mendoza', 'Raul Delgado', 'Cristian Herrera',
+            'Javier Guerrero', 'Eduardo Medina', 'Hector Aguilar', 'Omar Reyes'
+        ];
+
+        $positions = ['Goalkeeper', 'Defender', 'Midfielder', 'Forward'];
+        $nationalities = ['Indonesia', 'Brazil', 'Argentina', 'Spain', 'Portugal'];
+
+        $teams = Team::all();
+        foreach ($teams as $team) {
+            for ($i = 0; $i < 15; $i++) {
+                $name = $playerNames[array_rand($playerNames)];
+                $position = $positions[array_rand($positions)];
+                
+                Player::firstOrCreate([
+                    'name' => $name . ' ' . $team->name . ' ' . $i,
+                    'team_id' => $team->id,
+                ], [
+                    'position' => $position,
+                    'jersey_number' => $i + 1,
+                    'birth_date' => Carbon::now()->subYears(rand(18, 35)),
+                    'nationality' => $nationalities[array_rand($nationalities)],
+                    'height' => rand(165, 195),
+                    'weight' => rand(65, 85),
+                    'rating' => rand(30, 50) / 10,
+                    'goals_scored' => rand(0, 15),
+                    'assists' => rand(0, 10),
+                    'clean_sheets' => $position === 'Goalkeeper' ? rand(0, 8) : 0,
+                    'yellow_cards' => rand(0, 5),
+                    'red_cards' => rand(0, 2),
+                ]);
+            }
+        }
+
+        // Associate teams with tournaments
+        $premierLeague = Tournament::where('name', 'Premier League 2023')->first();
+        $championsLague = Tournament::where('name', 'Champions Cup')->first();
+        
+        if ($premierLeague) {
+            $teamsForPremier = Team::limit(6)->get();
+            foreach ($teamsForPremier as $index => $team) {
+                $premierLeague->teams()->attach($team->id, [
+                                            'status' => 'approved',
+                    'points' => rand(0, 30),
+                    'goals_for' => rand(5, 25),
+                    'goals_against' => rand(3, 20),
+                    'goal_difference' => rand(-10, 15),
+                    'matches_played' => rand(5, 15),
+                    'wins' => rand(0, 10),
+                    'draws' => rand(0, 5),
+                    'losses' => rand(0, 5),
+                ]);
+            }
+        }
+
+        if ($championsLague) {
+            $teamsForChampions = Team::skip(2)->limit(4)->get();
+            foreach ($teamsForChampions as $team) {
+                $championsLague->teams()->attach($team->id, [
+                    'status' => 'registered',
+                    'points' => 0,
+                    'goals_for' => 0,
+                    'goals_against' => 0,
+                    'goal_difference' => 0,
+                    'matches_played' => 0,
+                    'wins' => 0,
+                    'draws' => 0,
+                    'losses' => 0,
+                ]);
+            }
+        }
+
+        // Create matches
+        if ($premierLeague) {
+            $tournamentTeams = $premierLeague->teams;
+            for ($i = 0; $i < 10; $i++) {
+                $homeTeam = $tournamentTeams->random();
+                $awayTeam = $tournamentTeams->where('id', '!=', $homeTeam->id)->random();
+                
+                $isCompleted = rand(0, 1);
+                $scheduledAt = $isCompleted ? 
+                    Carbon::now()->subDays(rand(1, 20)) : 
+                    Carbon::now()->addDays(rand(1, 30));
+                
+                $match = MatchModel::firstOrCreate([
+                    'tournament_id' => $premierLeague->id,
+                    'home_team_id' => $homeTeam->id,
+                    'away_team_id' => $awayTeam->id,
+                    'scheduled_at' => $scheduledAt,
+                ], [
+                    'stage' => 'group',
+                    'status' => $isCompleted ? 'completed' : 'scheduled',
+                    'venue' => 'Stadium ' . ($i + 1),
+                    'home_score' => $isCompleted ? rand(0, 4) : null,
+                    'away_score' => $isCompleted ? rand(0, 4) : null,
+                    'notes' => 'Match ' . ($i + 1) . ' notes',
+                ]);
+
+                // Create match events for completed matches
+                if ($isCompleted && $match->home_score > 0) {
+                    $homePlayer = $homeTeam->players->random();
+                    MatchEvent::firstOrCreate([
+                        'match_id' => $match->id,
+                        'player_id' => $homePlayer->id,
+                        'type' => 'goal',
+                        'minute' => rand(1, 90),
+                    ], [
+                        'description' => 'Great goal by ' . $homePlayer->name,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/resources/views/fuma/index.blade.php
+++ b/resources/views/fuma/index.blade.php
@@ -1,0 +1,330 @@
+@extends('layouts.fuma')
+
+@section('title', 'Football Tournament Management')
+
+@section('content')
+    <!-- Hero Section -->
+    <section class="hero-section animate__animated animate__fadeIn">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-lg-6">
+                    <h1 class="display-4 fw-bold mb-4">Football Tournament Management System</h1>
+                    <p class="lead mb-4">Manage your football tournaments with ease. Track teams, players, matches, and statistics all in one place.</p>
+                    <div class="d-flex gap-3">
+                        <a href="{{ route('fuma.tournaments.index') }}" class="btn btn-accent btn-lg px-4">
+                            <i class="fas fa-trophy me-2"></i> View Tournaments
+                        </a>
+                        <a href="{{ route('login') }}" class="btn btn-outline-light btn-lg px-4">
+                            <i class="fas fa-lock me-2"></i> Admin Login
+                        </a>
+                    </div>
+                </div>
+                <div class="col-lg-6 d-none d-lg-block">
+                    <img src="https://media.istockphoto.com/id/974754900/id/vektor/ilustrasi-vektor-banner-turnamen-sepak-bola-bola-di-latar-belakang-lapangan-sepak-bola.jpg?s=170667a&w=0&k=20&c=-a5zDG5lJGTK0r_N8LotOEZOuDurWzwN0fY4LVl09hQ=" alt="Football Tournament" class="img-fluid">
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Quick Stats -->
+    <section class="py-5 bg-light">
+        <div class="container">
+            <div class="row g-4">
+                <div class="col-md-3">
+                    <div class="stats-card bg-white slide-up" style="animation-delay: 0.1s;">
+                        <div class="stats-number text-primary">{{ $stats['active_tournaments'] }}</div>
+                        <div class="stats-label">Active Tournaments</div>
+                        <i class="fas fa-trophy mt-3 text-primary"></i>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="stats-card bg-white slide-up" style="animation-delay: 0.2s;">
+                        <div class="stats-number text-primary">{{ $stats['total_teams'] }}</div>
+                        <div class="stats-label">Registered Teams</div>
+                        <i class="fas fa-users mt-3 text-primary"></i>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="stats-card bg-white slide-up" style="animation-delay: 0.3s;">
+                        <div class="stats-number text-primary">{{ $stats['total_players'] }}</div>
+                        <div class="stats-label">Players</div>
+                        <i class="fas fa-user-circle mt-3 text-primary"></i>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="stats-card bg-white slide-up" style="animation-delay: 0.4s;">
+                        <div class="stats-number text-primary">{{ $stats['total_matches'] }}</div>
+                        <div class="stats-label">Matches Played</div>
+                        <i class="fas fa-futbol mt-3 text-primary"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Featured Tournaments -->
+    <section id="tournaments" class="py-5">
+        <div class="container">
+            <div class="section-header mb-5 text-center">
+                <h2 class="fw-bold">Featured Tournaments</h2>
+                <p class="text-muted">Join the excitement of our premier football tournaments</p>
+            </div>
+            
+            <div class="row g-4">
+                @forelse($featured_tournaments as $tournament)
+                <div class="col-lg-4 col-md-6">
+                    <div class="card h-100 animate__animated animate__fadeInUp" style="animation-delay: {{ $loop->index * 0.1 }}s;">
+                        @if($tournament->logo)
+                            <img src="{{ asset('storage/' . $tournament->logo) }}" class="card-img-top" alt="{{ $tournament->name }}">
+                        @else
+                            <img src="https://tse1.mm.bing.net/th/id/OIP.MaIk4N5rw51_K6gHkokGUgHaGl?pid=Api" class="card-img-top" alt="{{ $tournament->name }}">
+                        @endif
+                        <div class="card-body d-flex flex-column">
+                            <h5 class="card-title">{{ $tournament->name }}</h5>
+                            <p class="card-text flex-grow-1">{{ Str::limit($tournament->description, 100) }}</p>
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <span class="badge bg-{{ $tournament->status === 'ongoing' ? 'success' : ($tournament->status === 'upcoming' ? 'warning' : 'secondary') }}">
+                                    {{ ucfirst($tournament->status) }}
+                                </span>
+                                <small class="text-muted">
+                                    <i class="fas fa-calendar-alt me-1"></i>
+                                    {{ $tournament->start_date->format('M d, Y') }}
+                                </small>
+                            </div>
+                            <div class="d-flex justify-content-between align-items-center">
+                                <span class="text-muted">
+                                    <i class="fas fa-users me-1"></i>
+                                    {{ $tournament->teams->count() }}/{{ $tournament->max_teams }} teams
+                                </span>
+                                <a href="{{ route('fuma.tournaments.show', $tournament) }}" class="btn btn-sm btn-outline-primary">
+                                    View Details
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                @empty
+                <div class="col-12 text-center">
+                    <p class="text-muted">No tournaments available at the moment.</p>
+                </div>
+                @endforelse
+            </div>
+            
+            <div class="text-center mt-4">
+                <a href="{{ route('fuma.tournaments.index') }}" class="btn btn-primary px-4">
+                    <i class="fas fa-trophy me-2"></i> View All Tournaments
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Top Teams -->
+    <section id="teams" class="py-5 bg-light">
+        <div class="container">
+            <div class="section-header mb-5 text-center">
+                <h2 class="fw-bold">Top Teams</h2>
+                <p class="text-muted">Meet the highest-rated teams in our tournaments</p>
+            </div>
+            
+            <div class="row g-3">
+                @forelse($top_teams as $team)
+                <div class="col-lg-3 col-md-4 col-sm-6">
+                    <div class="card team-card h-100 text-center">
+                        <div class="card-body p-3">
+                            @if($team->logo)
+                                <img src="{{ asset('storage/' . $team->logo) }}" alt="{{ $team->name }}" class="team-logo-sm mb-2">
+                            @else
+                                <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $team->name }}" class="team-logo-sm mb-2">
+                            @endif
+                            <h6 class="card-title mb-1">{{ $team->name }}</h6>
+                            <div class="d-flex justify-content-center small mb-2">
+                                <span class="text-muted">
+                                    <i class="fas fa-map-marker-alt me-1"></i>{{ $team->city }}
+                                </span>
+                            </div>
+                            <div class="d-flex justify-content-center small mb-2">
+                                <span class="badge bg-light text-dark me-1">
+                                    <i class="fas fa-user me-1"></i>{{ $team->players->count() }}
+                                </span>
+                                <span class="badge bg-light text-dark">
+                                    <i class="fas fa-star text-warning me-1"></i>{{ number_format($team->rating, 1) }}
+                                </span>
+                            </div>
+                            <a href="{{ route('fuma.teams.show', $team) }}" class="btn btn-sm btn-outline-primary w-100">
+                                View Team
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                @empty
+                <div class="col-12 text-center">
+                    <p class="text-muted">No teams available at the moment.</p>
+                </div>
+                @endforelse
+            </div>
+            
+            <div class="text-center mt-4">
+                <a href="{{ route('fuma.teams.index') }}" class="btn btn-primary px-4">
+                    <i class="fas fa-users me-2"></i> View All Teams
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Upcoming Matches -->
+    <section id="matches" class="py-5">
+        <div class="container">
+            <div class="section-header mb-5 text-center">
+                <h2 class="fw-bold">Upcoming Matches</h2>
+                <p class="text-muted">Don't miss these exciting matches coming soon</p>
+            </div>
+            
+            <div class="row g-3">
+                @forelse($upcoming_matches as $match)
+                <div class="col-md-6">
+                    <div class="card match-card h-100">
+                        <div class="card-body p-3">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <span class="badge bg-primary">{{ ucwords(str_replace('_', ' ', $match->stage)) }}</span>
+                                <small class="text-muted">
+                                    <i class="fas fa-calendar-alt me-1"></i> 
+                                    {{ $match->scheduled_at->format('M d, H:i') }}
+                                </small>
+                            </div>
+                            
+                            <div class="d-flex align-items-center mb-2">
+                                <div class="d-flex align-items-center flex-grow-1">
+                                    @if($match->homeTeam->logo)
+                                        <img src="{{ asset('storage/' . $match->homeTeam->logo) }}" alt="{{ $match->homeTeam->name }}" class="team-logo-sm me-2">
+                                    @else
+                                        <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $match->homeTeam->name }}" class="team-logo-sm me-2">
+                                    @endif
+                                    <span class="text-truncate">{{ $match->homeTeam->name }}</span>
+                                </div>
+                                
+                                <div class="px-2 text-center flex-shrink-0">
+                                    <div class="vs-badge bg-light rounded-pill px-2 py-0 d-inline-block">
+                                        <small class="fw-bold">VS</small>
+                                    </div>
+                                </div>
+                                
+                                <div class="d-flex align-items-center flex-grow-1 justify-content-end">
+                                    <span class="text-truncate text-end">{{ $match->awayTeam->name }}</span>
+                                    @if($match->awayTeam->logo)
+                                        <img src="{{ asset('storage/' . $match->awayTeam->logo) }}" alt="{{ $match->awayTeam->name }}" class="team-logo-sm ms-2">
+                                    @else
+                                        <img src="https://tse2.mm.bing.net/th/id/OIP.lpgOZ4hPNpsQjk22cDyIegHaFf?pid=Api&P=0&h=180" alt="{{ $match->awayTeam->name }}" class="team-logo-sm ms-2">
+                                    @endif
+                                </div>
+                            </div>
+                            
+                            <div class="d-flex justify-content-between align-items-center">
+                                <span class="badge bg-light text-dark small">
+                                    <i class="fas fa-map-marker-alt me-1"></i> {{ $match->venue ?: 'TBD' }}
+                                </span>
+                                <div>
+                                    <a href="{{ route('fuma.matches.show', $match) }}" class="btn btn-sm btn-outline-primary">
+                                        <i class="fas fa-eye"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                @empty
+                <div class="col-12 text-center">
+                    <p class="text-muted">No upcoming matches scheduled.</p>
+                </div>
+                @endforelse
+            </div>
+            
+            <div class="text-center mt-4">
+                <a href="{{ route('fuma.matches.index') }}" class="btn btn-primary px-4">
+                    <i class="fas fa-list me-2"></i> View All Matches
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Top Players -->
+    <section id="players" class="py-5 bg-light">
+        <div class="container">
+            <div class="section-header mb-5 text-center">
+                <h2 class="fw-bold">Top Players</h2>
+                <p class="text-muted">Outstanding players making their mark in the tournaments</p>
+            </div>
+            
+            <div class="row g-4">
+                @forelse($top_players as $player)
+                <div class="col-lg-3 col-md-4 col-sm-6">
+                    <div class="card h-100 text-center">
+                        <div class="card-body">
+                            @if($player->avatar)
+                                <img src="{{ asset('storage/' . $player->avatar) }}" alt="{{ $player->name }}" class="rounded-circle mb-3" width="80" height="80" style="object-fit: cover;">
+                            @else
+                                <img src="https://ui-avatars.com/api/?name={{ urlencode($player->name) }}&size=80&background=2563eb&color=fff" alt="{{ $player->name }}" class="rounded-circle mb-3" width="80" height="80">
+                            @endif
+                            <h6 class="card-title">{{ $player->name }}</h6>
+                            <p class="text-muted small mb-2">{{ $player->position }}</p>
+                            @if($player->team)
+                                <p class="text-muted small mb-2">{{ $player->team->name }}</p>
+                            @endif
+                            <div class="d-flex justify-content-center gap-2 mb-2">
+                                <span class="badge bg-light text-dark">
+                                    <i class="fas fa-futbol me-1"></i>{{ $player->goals_scored }}
+                                </span>
+                                <span class="badge bg-light text-dark">
+                                    <i class="fas fa-star text-warning me-1"></i>{{ number_format($player->rating, 1) }}
+                                </span>
+                            </div>
+                            <a href="{{ route('fuma.players.show', $player) }}" class="btn btn-sm btn-outline-primary">
+                                View Profile
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                @empty
+                <div class="col-12 text-center">
+                    <p class="text-muted">No players available at the moment.</p>
+                </div>
+                @endforelse
+            </div>
+            
+            <div class="text-center mt-4">
+                <a href="{{ route('fuma.players.index') }}" class="btn btn-primary px-4">
+                    <i class="fas fa-users me-2"></i> View All Players
+                </a>
+            </div>
+        </div>
+    </section>
+@endsection
+
+@push('styles')
+<style>
+    .team-card {
+        transition: all 0.3s ease;
+        border: none;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+    }
+    
+    .team-card:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+    }
+    
+    .team-card:hover .team-logo-sm {
+        transform: scale(1.1);
+    }
+    
+    .vs-badge {
+        min-width: 40px;
+    }
+    
+    .text-truncate {
+        max-width: 100px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+</style>
+@endpush

--- a/resources/views/fuma/matches/create.blade.php
+++ b/resources/views/fuma/matches/create.blade.php
@@ -1,0 +1,212 @@
+@extends('layouts.fuma')
+
+@section('title', 'Schedule Match - Football Tournament Management')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <h1 class="fw-bold mb-2">Schedule New Match</h1>
+                    <p class="mb-0">Schedule a match between two teams</p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <a href="{{ route('fuma.matches.index') }}" class="btn btn-outline-light">
+                        <i class="fas fa-arrow-left me-2"></i> Back to Matches
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="card">
+                    <div class="card-body">
+                        <form action="{{ route('fuma.matches.store') }}" method="POST">
+                            @csrf
+                            
+                            <div class="mb-3">
+                                <label for="tournament_id" class="form-label">Tournament <span class="text-danger">*</span></label>
+                                <select class="form-select @error('tournament_id') is-invalid @enderror" id="tournament_id" name="tournament_id" required>
+                                    <option value="">Select tournament</option>
+                                    @foreach($tournaments as $tournament)
+                                        <option value="{{ $tournament->id }}" {{ old('tournament_id') == $tournament->id ? 'selected' : '' }}>
+                                            {{ $tournament->name }} ({{ ucfirst($tournament->status) }})
+                                        </option>
+                                    @endforeach
+                                </select>
+                                @error('tournament_id')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="home_team_id" class="form-label">Home Team <span class="text-danger">*</span></label>
+                                    <select class="form-select @error('home_team_id') is-invalid @enderror" id="home_team_id" name="home_team_id" required>
+                                        <option value="">Select home team</option>
+                                        @foreach($teams as $team)
+                                            <option value="{{ $team->id }}" {{ old('home_team_id') == $team->id ? 'selected' : '' }}>{{ $team->name }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('home_team_id')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="away_team_id" class="form-label">Away Team <span class="text-danger">*</span></label>
+                                    <select class="form-select @error('away_team_id') is-invalid @enderror" id="away_team_id" name="away_team_id" required>
+                                        <option value="">Select away team</option>
+                                        @foreach($teams as $team)
+                                            <option value="{{ $team->id }}" {{ old('away_team_id') == $team->id ? 'selected' : '' }}>{{ $team->name }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('away_team_id')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="stage" class="form-label">Stage <span class="text-danger">*</span></label>
+                                    <select class="form-select @error('stage') is-invalid @enderror" id="stage" name="stage" required>
+                                        <option value="">Select stage</option>
+                                        <option value="group" {{ old('stage') === 'group' ? 'selected' : '' }}>Group Stage</option>
+                                        <option value="round_of_16" {{ old('stage') === 'round_of_16' ? 'selected' : '' }}>Round of 16</option>
+                                        <option value="quarter_final" {{ old('stage') === 'quarter_final' ? 'selected' : '' }}>Quarter Final</option>
+                                        <option value="semi_final" {{ old('stage') === 'semi_final' ? 'selected' : '' }}>Semi Final</option>
+                                        <option value="final" {{ old('stage') === 'final' ? 'selected' : '' }}>Final</option>
+                                    </select>
+                                    @error('stage')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="venue" class="form-label">Venue</label>
+                                    <input type="text" class="form-control @error('venue') is-invalid @enderror" 
+                                           id="venue" name="venue" value="{{ old('venue') }}">
+                                    @error('venue')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="scheduled_date" class="form-label">Match Date <span class="text-danger">*</span></label>
+                                    <input type="date" class="form-control @error('scheduled_at') is-invalid @enderror" 
+                                           id="scheduled_date" name="scheduled_date" value="{{ old('scheduled_date') }}" required>
+                                    @error('scheduled_at')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="scheduled_time" class="form-label">Match Time <span class="text-danger">*</span></label>
+                                    <input type="time" class="form-control @error('scheduled_at') is-invalid @enderror" 
+                                           id="scheduled_time" name="scheduled_time" value="{{ old('scheduled_time') }}" required>
+                                </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="notes" class="form-label">Notes</label>
+                                <textarea class="form-control @error('notes') is-invalid @enderror" 
+                                          id="notes" name="notes" rows="3">{{ old('notes') }}</textarea>
+                                @error('notes')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div class="d-flex gap-2">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-save me-2"></i> Schedule Match
+                                </button>
+                                <a href="{{ route('fuma.matches.index') }}" class="btn btn-outline-secondary">
+                                    <i class="fas fa-times me-2"></i> Cancel
+                                </a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+// Prevent selecting the same team for both home and away
+document.getElementById('home_team_id').addEventListener('change', function() {
+    const homeTeamId = this.value;
+    const awaySelect = document.getElementById('away_team_id');
+    
+    // Enable all options first
+    Array.from(awaySelect.options).forEach(option => {
+        option.disabled = false;
+    });
+    
+    // Disable the selected home team in away team dropdown
+    if (homeTeamId) {
+        Array.from(awaySelect.options).forEach(option => {
+            if (option.value === homeTeamId) {
+                option.disabled = true;
+            }
+        });
+        
+        // If away team is same as home team, reset it
+        if (awaySelect.value === homeTeamId) {
+            awaySelect.value = '';
+        }
+    }
+});
+
+document.getElementById('away_team_id').addEventListener('change', function() {
+    const awayTeamId = this.value;
+    const homeSelect = document.getElementById('home_team_id');
+    
+    // Enable all options first
+    Array.from(homeSelect.options).forEach(option => {
+        option.disabled = false;
+    });
+    
+    // Disable the selected away team in home team dropdown
+    if (awayTeamId) {
+        Array.from(homeSelect.options).forEach(option => {
+            if (option.value === awayTeamId) {
+                option.disabled = true;
+            }
+        });
+        
+        // If home team is same as away team, reset it
+        if (homeSelect.value === awayTeamId) {
+            homeSelect.value = '';
+        }
+    }
+});
+
+// Combine date and time before form submission
+document.querySelector('form').addEventListener('submit', function(e) {
+    const date = document.getElementById('scheduled_date').value;
+    const time = document.getElementById('scheduled_time').value;
+    
+    if (date && time) {
+        const scheduledAt = date + ' ' + time;
+        
+        // Create hidden input for scheduled_at
+        const hiddenInput = document.createElement('input');
+        hiddenInput.type = 'hidden';
+        hiddenInput.name = 'scheduled_at';
+        hiddenInput.value = scheduledAt;
+        
+        this.appendChild(hiddenInput);
+    }
+});
+</script>
+@endpush

--- a/resources/views/fuma/matches/index.blade.php
+++ b/resources/views/fuma/matches/index.blade.php
@@ -1,0 +1,190 @@
+@extends('layouts.fuma')
+
+@section('title', 'All Matches - Football Tournament Management')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <h1 class="fw-bold mb-2">All Matches</h1>
+                    <p class="mb-0">View and manage football matches</p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <div class="d-flex gap-2 justify-content-md-end">
+                        <a href="{{ route('fuma.matches.create') }}" class="btn btn-light">
+                            <i class="fas fa-plus me-2"></i> Schedule Match
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <!-- Filters -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card filter-card">
+                    <div class="card-body">
+                        <form method="GET" action="{{ route('fuma.matches.index') }}">
+                            <div class="row g-3">
+                                <div class="col-md-3">
+                                    <label for="status" class="form-label">Status</label>
+                                    <select class="form-select" id="status" name="status">
+                                        <option value="">All Status</option>
+                                        <option value="scheduled" {{ request('status') === 'scheduled' ? 'selected' : '' }}>Scheduled</option>
+                                        <option value="live" {{ request('status') === 'live' ? 'selected' : '' }}>Live</option>
+                                        <option value="completed" {{ request('status') === 'completed' ? 'selected' : '' }}>Completed</option>
+                                        <option value="cancelled" {{ request('status') === 'cancelled' ? 'selected' : '' }}>Cancelled</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="tournament" class="form-label">Tournament</label>
+                                    <select class="form-select" id="tournament" name="tournament">
+                                        <option value="">All Tournaments</option>
+                                        @foreach($tournaments as $tournament)
+                                            <option value="{{ $tournament->id }}" {{ request('tournament') == $tournament->id ? 'selected' : '' }}>
+                                                {{ $tournament->name }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="date" class="form-label">Date</label>
+                                    <input type="date" class="form-control" id="date" name="date" value="{{ request('date') }}">
+                                </div>
+                                <div class="col-md-3 d-flex align-items-end">
+                                    <button type="submit" class="btn btn-primary me-2">
+                                        <i class="fas fa-search me-1"></i> Filter
+                                    </button>
+                                    <a href="{{ route('fuma.matches.index') }}" class="btn btn-outline-secondary">
+                                        <i class="fas fa-undo me-1"></i> Reset
+                                    </a>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Matches Table -->
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Date & Time</th>
+                                        <th>Tournament</th>
+                                        <th>Stage</th>
+                                        <th>Home Team</th>
+                                        <th>Score</th>
+                                        <th>Away Team</th>
+                                        <th>Venue</th>
+                                        <th>Status</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse($matches as $match)
+                                    <tr>
+                                        <td>
+                                            <div>
+                                                <strong>{{ $match->scheduled_at->format('M d, Y') }}</strong><br>
+                                                <small class="text-muted">{{ $match->scheduled_at->format('H:i') }}</small>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('fuma.tournaments.show', $match->tournament) }}" class="text-decoration-none">
+                                                {{ $match->tournament->name }}
+                                            </a>
+                                        </td>
+                                        <td>
+                                            <span class="badge bg-primary">{{ ucwords(str_replace('_', ' ', $match->stage)) }}</span>
+                                        </td>
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                @if($match->homeTeam->logo)
+                                                    <img src="{{ asset('storage/' . $match->homeTeam->logo) }}" alt="{{ $match->homeTeam->name }}" class="team-logo-sm me-2">
+                                                @else
+                                                    <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $match->homeTeam->name }}" class="team-logo-sm me-2">
+                                                @endif
+                                                <span>{{ $match->homeTeam->name }}</span>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            @if($match->status === 'completed')
+                                                <span class="match-score">{{ $match->home_score }} - {{ $match->away_score }}</span>
+                                            @elseif($match->status === 'live')
+                                                <span class="badge bg-danger live-badge">LIVE</span>
+                                            @else
+                                                <span class="text-muted">vs</span>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                @if($match->awayTeam->logo)
+                                                    <img src="{{ asset('storage/' . $match->awayTeam->logo) }}" alt="{{ $match->awayTeam->name }}" class="team-logo-sm me-2">
+                                                @else
+                                                    <img src="https://tse2.mm.bing.net/th/id/OIP.lpgOZ4hPNpsQjk22cDyIegHaFf?pid=Api&P=0&h=180" alt="{{ $match->awayTeam->name }}" class="team-logo-sm me-2">
+                                                @endif
+                                                <span>{{ $match->awayTeam->name }}</span>
+                                            </div>
+                                        </td>
+                                        <td>{{ $match->venue ?: 'TBD' }}</td>
+                                        <td>
+                                            @if($match->status === 'live')
+                                                <span class="badge bg-danger live-badge">Live</span>
+                                            @elseif($match->status === 'completed')
+                                                <span class="badge bg-success">Completed</span>
+                                            @elseif($match->status === 'cancelled')
+                                                <span class="badge bg-secondary">Cancelled</span>
+                                            @else
+                                                <span class="badge bg-warning">Scheduled</span>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('fuma.matches.show', $match) }}" class="btn btn-sm btn-outline-primary action-btn">
+                                                <i class="fas fa-eye"></i> View
+                                            </a>
+                                        </td>
+                                    </tr>
+                                    @empty
+                                    <tr>
+                                        <td colspan="9" class="text-center py-4">
+                                            <div class="text-muted">
+                                                <i class="fas fa-futbol fa-3x mb-3"></i>
+                                                <p>No matches found matching your criteria.</p>
+                                                <a href="{{ route('fuma.matches.create') }}" class="btn btn-primary">
+                                                    <i class="fas fa-plus me-2"></i> Schedule First Match
+                                                </a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Pagination -->
+        @if($matches->hasPages())
+        <div class="row mt-4">
+            <div class="col-12">
+                <div class="d-flex justify-content-center">
+                    {{ $matches->links() }}
+                </div>
+            </div>
+        </div>
+        @endif
+    </div>
+@endsection

--- a/resources/views/fuma/matches/show.blade.php
+++ b/resources/views/fuma/matches/show.blade.php
@@ -1,0 +1,331 @@
+@extends('layouts.fuma')
+
+@section('title', $match->homeTeam->name . ' vs ' . $match->awayTeam->name . ' - Match Details')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-8">
+                    <div class="mb-2">
+                        <a href="{{ route('fuma.tournaments.show', $match->tournament) }}" class="text-light text-decoration-none">
+                            <i class="fas fa-trophy me-2"></i>{{ $match->tournament->name }}
+                        </a>
+                    </div>
+                    <h1 class="fw-bold mb-1">{{ $match->homeTeam->name }} vs {{ $match->awayTeam->name }}</h1>
+                    <p class="mb-0">
+                        <i class="fas fa-calendar-alt me-2"></i>{{ $match->scheduled_at->format('F d, Y \a\t H:i') }}
+                        @if($match->venue)
+                            <i class="fas fa-map-marker-alt me-2 ms-3"></i>{{ $match->venue }}
+                        @endif
+                    </p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <div class="d-flex gap-2 justify-content-md-end">
+                        @if(auth()->check() && $match->status !== 'completed')
+                            <button class="btn btn-light" data-bs-toggle="modal" data-bs-target="#updateScoreModal">
+                                <i class="fas fa-edit me-2"></i> Update Score
+                            </button>
+                        @endif
+                        <a href="{{ route('fuma.matches.index') }}" class="btn btn-outline-light">
+                            <i class="fas fa-arrow-left me-2"></i> Back to Matches
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Match Score Section -->
+    <div class="container">
+        <div class="row justify-content-center mb-4">
+            <div class="col-lg-8">
+                <div class="card">
+                    <div class="card-body py-4">
+                        <div class="row align-items-center text-center">
+                            <!-- Home Team -->
+                            <div class="col-4">
+                                <div class="team-section">
+                                    @if($match->homeTeam->logo)
+                                        <img src="{{ asset('storage/' . $match->homeTeam->logo) }}" alt="{{ $match->homeTeam->name }}" class="team-logo-lg mb-3">
+                                    @else
+                                        <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $match->homeTeam->name }}" class="team-logo-lg mb-3">
+                                    @endif
+                                    <h4 class="fw-bold">{{ $match->homeTeam->name }}</h4>
+                                    <small class="text-muted">Home</small>
+                                </div>
+                            </div>
+
+                            <!-- Score -->
+                            <div class="col-4">
+                                <div class="score-section">
+                                    @if($match->status === 'completed')
+                                        <div class="score-display">
+                                            <span class="score-number">{{ $match->home_score }}</span>
+                                            <span class="score-separator">-</span>
+                                            <span class="score-number">{{ $match->away_score }}</span>
+                                        </div>
+                                        <div class="match-status">
+                                            <span class="badge bg-success">Full Time</span>
+                                        </div>
+                                    @elseif($match->status === 'live')
+                                        <div class="score-display">
+                                            <span class="score-number">{{ $match->home_score ?? 0 }}</span>
+                                            <span class="score-separator">-</span>
+                                            <span class="score-number">{{ $match->away_score ?? 0 }}</span>
+                                        </div>
+                                        <div class="match-status">
+                                            <span class="badge bg-danger live-badge">LIVE</span>
+                                        </div>
+                                    @else
+                                        <div class="match-time">
+                                            <h3 class="fw-bold">{{ $match->scheduled_at->format('H:i') }}</h3>
+                                            <span class="badge bg-warning">{{ ucfirst($match->status) }}</span>
+                                        </div>
+                                    @endif
+                                    <div class="match-info mt-2">
+                                        <small class="text-muted">{{ ucwords(str_replace('_', ' ', $match->stage)) }}</small>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Away Team -->
+                            <div class="col-4">
+                                <div class="team-section">
+                                    @if($match->awayTeam->logo)
+                                        <img src="{{ asset('storage/' . $match->awayTeam->logo) }}" alt="{{ $match->awayTeam->name }}" class="team-logo-lg mb-3">
+                                    @else
+                                        <img src="https://tse2.mm.bing.net/th/id/OIP.lpgOZ4hPNpsQjk22cDyIegHaFf?pid=Api&P=0&h=180" alt="{{ $match->awayTeam->name }}" class="team-logo-lg mb-3">
+                                    @endif
+                                    <h4 class="fw-bold">{{ $match->awayTeam->name }}</h4>
+                                    <small class="text-muted">Away</small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Match Events -->
+        @if($match->events->count() > 0)
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Match Events</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="timeline">
+                            @foreach($match->events->sortBy('minute') as $event)
+                            <div class="timeline-item">
+                                <div class="timeline-marker bg-{{ $event->type === 'goal' ? 'success' : ($event->type === 'yellow_card' ? 'warning' : 'danger') }}">
+                                    <i class="fas fa-{{ $event->type === 'goal' ? 'futbol' : ($event->type === 'yellow_card' ? 'square' : 'square') }}"></i>
+                                </div>
+                                <div class="timeline-content">
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <div>
+                                            <strong>{{ $event->player->name ?? 'Unknown Player' }}</strong>
+                                            <span class="text-muted">- {{ ucwords(str_replace('_', ' ', $event->type)) }}</span>
+                                        </div>
+                                        <span class="badge bg-light text-dark">{{ $event->minute }}'</span>
+                                    </div>
+                                    @if($event->description)
+                                        <small class="text-muted">{{ $event->description }}</small>
+                                    @endif
+                                </div>
+                            </div>
+                            @endforeach
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        @endif
+
+        <!-- Team Lineups -->
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">{{ $match->homeTeam->name }} Lineup</h5>
+                    </div>
+                    <div class="card-body">
+                        @if($match->homeTeam->players->count() > 0)
+                            <div class="list-group list-group-flush">
+                                @foreach($match->homeTeam->players->take(11) as $player)
+                                <div class="list-group-item d-flex align-items-center px-0">
+                                    @if($player->jersey_number)
+                                        <span class="badge bg-primary me-3">#{{ $player->jersey_number }}</span>
+                                    @else
+                                        <span class="badge bg-secondary me-3">-</span>
+                                    @endif
+                                    @if($player->avatar)
+                                        <img src="{{ asset('storage/' . $player->avatar) }}" alt="{{ $player->name }}" class="rounded-circle me-2" width="32" height="32" style="object-fit: cover;">
+                                    @else
+                                        <img src="https://ui-avatars.com/api/?name={{ urlencode($player->name) }}&size=32&background=2563eb&color=fff" alt="{{ $player->name }}" class="rounded-circle me-2" width="32" height="32">
+                                    @endif
+                                    <div>
+                                        <strong>{{ $player->name }}</strong><br>
+                                        <small class="text-muted">{{ $player->position }}</small>
+                                    </div>
+                                </div>
+                                @endforeach
+                            </div>
+                        @else
+                            <p class="text-muted text-center py-3">No players available</p>
+                        @endif
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">{{ $match->awayTeam->name }} Lineup</h5>
+                    </div>
+                    <div class="card-body">
+                        @if($match->awayTeam->players->count() > 0)
+                            <div class="list-group list-group-flush">
+                                @foreach($match->awayTeam->players->take(11) as $player)
+                                <div class="list-group-item d-flex align-items-center px-0">
+                                    @if($player->jersey_number)
+                                        <span class="badge bg-primary me-3">#{{ $player->jersey_number }}</span>
+                                    @else
+                                        <span class="badge bg-secondary me-3">-</span>
+                                    @endif
+                                    @if($player->avatar)
+                                        <img src="{{ asset('storage/' . $player->avatar) }}" alt="{{ $player->name }}" class="rounded-circle me-2" width="32" height="32" style="object-fit: cover;">
+                                    @else
+                                        <img src="https://ui-avatars.com/api/?name={{ urlencode($player->name) }}&size=32&background=2563eb&color=fff" alt="{{ $player->name }}" class="rounded-circle me-2" width="32" height="32">
+                                    @endif
+                                    <div>
+                                        <strong>{{ $player->name }}</strong><br>
+                                        <small class="text-muted">{{ $player->position }}</small>
+                                    </div>
+                                </div>
+                                @endforeach
+                            </div>
+                        @else
+                            <p class="text-muted text-center py-3">No players available</p>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Update Score Modal -->
+    @if(auth()->check() && $match->status !== 'completed')
+    <div class="modal fade" id="updateScoreModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Update Match Score</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form action="{{ route('fuma.matches.updateScore', $match) }}" method="POST">
+                    @csrf
+                    @method('PATCH')
+                    <div class="modal-body">
+                        <div class="row">
+                            <div class="col-6">
+                                <label for="home_score" class="form-label">{{ $match->homeTeam->name }} Score</label>
+                                <input type="number" class="form-control" id="home_score" name="home_score" 
+                                       value="{{ $match->home_score ?? 0 }}" min="0" required>
+                            </div>
+                            <div class="col-6">
+                                <label for="away_score" class="form-label">{{ $match->awayTeam->name }} Score</label>
+                                <input type="number" class="form-control" id="away_score" name="away_score" 
+                                       value="{{ $match->away_score ?? 0 }}" min="0" required>
+                            </div>
+                        </div>
+                        <div class="mt-3">
+                            <label for="status" class="form-label">Match Status</label>
+                            <select class="form-select" id="status" name="status" required>
+                                <option value="live" {{ $match->status === 'live' ? 'selected' : '' }}>Live</option>
+                                <option value="completed" {{ $match->status === 'completed' ? 'selected' : '' }}>Completed</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Update Score</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    @endif
+@endsection
+
+@push('styles')
+<style>
+.team-logo-lg {
+    width: 80px;
+    height: 80px;
+    object-fit: contain;
+}
+
+.score-display {
+    font-size: 3rem;
+    font-weight: bold;
+    line-height: 1;
+}
+
+.score-number {
+    color: var(--primary-color);
+}
+
+.score-separator {
+    color: #6c757d;
+    margin: 0 15px;
+}
+
+.match-time h3 {
+    color: var(--primary-color);
+}
+
+.timeline {
+    position: relative;
+    padding-left: 30px;
+}
+
+.timeline-item {
+    position: relative;
+    padding-bottom: 20px;
+}
+
+.timeline-item:not(:last-child):before {
+    content: '';
+    position: absolute;
+    left: -19px;
+    top: 30px;
+    height: calc(100% - 10px);
+    width: 2px;
+    background-color: #dee2e6;
+}
+
+.timeline-marker {
+    position: absolute;
+    left: -30px;
+    top: 5px;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 12px;
+}
+
+.timeline-content {
+    background-color: #f8f9fa;
+    padding: 15px;
+    border-radius: 8px;
+    border-left: 3px solid var(--primary-color);
+}
+</style>
+@endpush

--- a/resources/views/fuma/players/create.blade.php
+++ b/resources/views/fuma/players/create.blade.php
@@ -1,0 +1,144 @@
+@extends('layouts.fuma')
+
+@section('title', 'Add Player - Football Tournament Management')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <h1 class="fw-bold mb-2">Add New Player</h1>
+                    <p class="mb-0">Register a new football player</p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <a href="{{ route('fuma.players.index') }}" class="btn btn-outline-light">
+                        <i class="fas fa-arrow-left me-2"></i> Back to Players
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="card">
+                    <div class="card-body">
+                        <form action="{{ route('fuma.players.store') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="name" class="form-label">Player Name <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control @error('name') is-invalid @enderror" 
+                                           id="name" name="name" value="{{ old('name') }}" required>
+                                    @error('name')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="position" class="form-label">Position <span class="text-danger">*</span></label>
+                                    <select class="form-select @error('position') is-invalid @enderror" id="position" name="position" required>
+                                        <option value="">Select position</option>
+                                        @foreach($positions as $position)
+                                            <option value="{{ $position }}" {{ old('position') === $position ? 'selected' : '' }}>{{ $position }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('position')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="team_id" class="form-label">Team</label>
+                                    <select class="form-select @error('team_id') is-invalid @enderror" id="team_id" name="team_id">
+                                        <option value="">Select team (optional)</option>
+                                        @foreach($teams as $team)
+                                            <option value="{{ $team->id }}" {{ old('team_id', request('team_id')) == $team->id ? 'selected' : '' }}>{{ $team->name }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('team_id')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="jersey_number" class="form-label">Jersey Number</label>
+                                    <input type="text" class="form-control @error('jersey_number') is-invalid @enderror" 
+                                           id="jersey_number" name="jersey_number" value="{{ old('jersey_number') }}" maxlength="3">
+                                    @error('jersey_number')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="birth_date" class="form-label">Birth Date</label>
+                                    <input type="date" class="form-control @error('birth_date') is-invalid @enderror" 
+                                           id="birth_date" name="birth_date" value="{{ old('birth_date') }}">
+                                    @error('birth_date')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="nationality" class="form-label">Nationality <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control @error('nationality') is-invalid @enderror" 
+                                           id="nationality" name="nationality" value="{{ old('nationality', 'Indonesia') }}" required>
+                                    @error('nationality')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="height" class="form-label">Height (cm)</label>
+                                    <input type="number" class="form-control @error('height') is-invalid @enderror" 
+                                           id="height" name="height" value="{{ old('height') }}" min="100" max="250" step="0.01">
+                                    @error('height')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="weight" class="form-label">Weight (kg)</label>
+                                    <input type="number" class="form-control @error('weight') is-invalid @enderror" 
+                                           id="weight" name="weight" value="{{ old('weight') }}" min="40" max="150" step="0.01">
+                                    @error('weight')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="avatar" class="form-label">Player Photo</label>
+                                <input type="file" class="form-control @error('avatar') is-invalid @enderror" 
+                                       id="avatar" name="avatar" accept="image/*">
+                                @error('avatar')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                                <div class="form-text">Max file size: 2MB. Supported formats: JPEG, PNG, JPG, GIF</div>
+                            </div>
+
+                            <div class="d-flex gap-2">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-save me-2"></i> Add Player
+                                </button>
+                                <a href="{{ route('fuma.players.index') }}" class="btn btn-outline-secondary">
+                                    <i class="fas fa-times me-2"></i> Cancel
+                                </a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/fuma/players/index.blade.php
+++ b/resources/views/fuma/players/index.blade.php
@@ -1,0 +1,146 @@
+@extends('layouts.fuma')
+
+@section('title', 'All Players - Football Tournament Management')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <h1 class="fw-bold mb-2">All Players</h1>
+                    <p class="mb-0">Browse and manage football players</p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <div class="d-flex gap-2 justify-content-md-end">
+                        <a href="{{ route('fuma.players.create') }}" class="btn btn-light">
+                            <i class="fas fa-plus me-2"></i> Add Player
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <!-- Filters -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card filter-card">
+                    <div class="card-body">
+                        <form method="GET" action="{{ route('fuma.players.index') }}">
+                            <div class="row g-3">
+                                <div class="col-md-2">
+                                    <label for="position" class="form-label">Position</label>
+                                    <select class="form-select" id="position" name="position">
+                                        <option value="">All Positions</option>
+                                        <option value="Goalkeeper" {{ request('position') === 'Goalkeeper' ? 'selected' : '' }}>Goalkeeper</option>
+                                        <option value="Defender" {{ request('position') === 'Defender' ? 'selected' : '' }}>Defender</option>
+                                        <option value="Midfielder" {{ request('position') === 'Midfielder' ? 'selected' : '' }}>Midfielder</option>
+                                        <option value="Forward" {{ request('position') === 'Forward' ? 'selected' : '' }}>Forward</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="team" class="form-label">Team</label>
+                                    <select class="form-select" id="team" name="team">
+                                        <option value="">All Teams</option>
+                                        @foreach($teams as $team)
+                                            <option value="{{ $team->id }}" {{ request('team') == $team->id ? 'selected' : '' }}>{{ $team->name }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="search" class="form-label">Search</label>
+                                    <input type="text" class="form-control" id="search" name="search" 
+                                           placeholder="Player name..." value="{{ request('search') }}">
+                                </div>
+                                <div class="col-md-2">
+                                    <label for="sort" class="form-label">Sort By</label>
+                                    <select class="form-select" id="sort" name="sort">
+                                        <option value="name" {{ request('sort') === 'name' ? 'selected' : '' }}>Name</option>
+                                        <option value="rating" {{ request('sort') === 'rating' ? 'selected' : '' }}>Rating</option>
+                                        <option value="goals" {{ request('sort') === 'goals' ? 'selected' : '' }}>Goals</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-2 d-flex align-items-end">
+                                    <button type="submit" class="btn btn-primary me-2">
+                                        <i class="fas fa-search me-1"></i> Filter
+                                    </button>
+                                    <a href="{{ route('fuma.players.index') }}" class="btn btn-outline-secondary">
+                                        <i class="fas fa-undo me-1"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Players Grid -->
+        <div class="row g-4">
+            @forelse($players as $player)
+            <div class="col-lg-3 col-md-4 col-sm-6">
+                <div class="card h-100 text-center">
+                    <div class="card-body">
+                        @if($player->avatar)
+                            <img src="{{ asset('storage/' . $player->avatar) }}" alt="{{ $player->name }}" class="rounded-circle mb-3" width="80" height="80" style="object-fit: cover;">
+                        @else
+                            <img src="https://ui-avatars.com/api/?name={{ urlencode($player->name) }}&size=80&background=2563eb&color=fff" alt="{{ $player->name }}" class="rounded-circle mb-3" width="80" height="80">
+                        @endif
+                        <h6 class="card-title">{{ $player->name }}</h6>
+                        @if($player->jersey_number)
+                            <div class="badge bg-primary mb-2">#{{ $player->jersey_number }}</div>
+                        @endif
+                        <p class="text-muted small mb-2">{{ $player->position }}</p>
+                        @if($player->team)
+                            <p class="text-muted small mb-2">{{ $player->team->name }}</p>
+                        @endif
+                        <div class="d-flex justify-content-center gap-1 mb-3 flex-wrap">
+                            <span class="badge bg-light text-dark small">
+                                <i class="fas fa-futbol me-1"></i>{{ $player->goals_scored }}
+                            </span>
+                            <span class="badge bg-light text-dark small">
+                                <i class="fas fa-hands-helping me-1"></i>{{ $player->assists }}
+                            </span>
+                            <span class="badge bg-light text-dark small">
+                                <i class="fas fa-star text-warning me-1"></i>{{ number_format($player->rating, 1) }}
+                            </span>
+                        </div>
+                        @if($player->nationality)
+                            <p class="text-muted small mb-2">
+                                <i class="fas fa-flag me-1"></i> {{ $player->nationality }}
+                            </p>
+                        @endif
+                        <a href="{{ route('fuma.players.show', $player) }}" class="btn btn-sm btn-outline-primary">
+                            View Profile
+                        </a>
+                    </div>
+                </div>
+            </div>
+            @empty
+            <div class="col-12 text-center py-5">
+                <div class="text-muted">
+                    <i class="fas fa-user-circle fa-3x mb-3"></i>
+                    <p>No players found matching your criteria.</p>
+                    <a href="{{ route('fuma.players.create') }}" class="btn btn-primary">
+                        <i class="fas fa-plus me-2"></i> Add First Player
+                    </a>
+                </div>
+            </div>
+            @endforelse
+        </div>
+
+        <!-- Pagination -->
+        @if($players->hasPages())
+        <div class="row mt-4">
+            <div class="col-12">
+                <div class="d-flex justify-content-center">
+                    {{ $players->links() }}
+                </div>
+            </div>
+        </div>
+        @endif
+    </div>
+@endsection

--- a/resources/views/fuma/players/show.blade.php
+++ b/resources/views/fuma/players/show.blade.php
@@ -1,0 +1,221 @@
+@extends('layouts.fuma')
+
+@section('title', $player->name . ' - Player Profile')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-8">
+                    <div class="d-flex align-items-center">
+                        @if($player->avatar)
+                            <img src="{{ asset('storage/' . $player->avatar) }}" alt="{{ $player->name }}" class="rounded-circle me-3" width="80" height="80" style="object-fit: cover;">
+                        @else
+                            <img src="https://ui-avatars.com/api/?name={{ urlencode($player->name) }}&size=80&background=2563eb&color=fff" alt="{{ $player->name }}" class="rounded-circle me-3" width="80" height="80">
+                        @endif
+                        <div>
+                            <h1 class="fw-bold mb-1">{{ $player->name }}</h1>
+                            <p class="mb-0">
+                                {{ $player->position }}
+                                @if($player->jersey_number)
+                                    <span class="badge bg-primary ms-2">#{{ $player->jersey_number }}</span>
+                                @endif
+                            </p>
+                            @if($player->team)
+                                <p class="mb-0 text-light">
+                                    <i class="fas fa-users me-2"></i>{{ $player->team->name }}
+                                </p>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <div class="d-flex gap-2 justify-content-md-end">
+                        @if(auth()->check())
+                            <button class="btn btn-light">
+                                <i class="fas fa-edit me-2"></i> Edit Player
+                            </button>
+                        @endif
+                        <a href="{{ route('fuma.players.index') }}" class="btn btn-outline-light">
+                            <i class="fas fa-arrow-left me-2"></i> Back to Players
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <div class="row">
+            <!-- Player Information -->
+            <div class="col-lg-4">
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Player Information</h5>
+                    </div>
+                    <div class="card-body">
+                        <ul class="list-group list-group-flush">
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-futbol me-2"></i>Position</span>
+                                <span class="fw-bold">{{ $player->position }}</span>
+                            </li>
+                            @if($player->jersey_number)
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-tshirt me-2"></i>Jersey Number</span>
+                                <span class="fw-bold">#{{ $player->jersey_number }}</span>
+                            </li>
+                            @endif
+                            @if($player->age)
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-birthday-cake me-2"></i>Age</span>
+                                <span class="fw-bold">{{ $player->age }} years</span>
+                            </li>
+                            @endif
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-flag me-2"></i>Nationality</span>
+                                <span class="fw-bold">{{ $player->nationality }}</span>
+                            </li>
+                            @if($player->height)
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-ruler-vertical me-2"></i>Height</span>
+                                <span class="fw-bold">{{ $player->height }} cm</span>
+                            </li>
+                            @endif
+                            @if($player->weight)
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-weight me-2"></i>Weight</span>
+                                <span class="fw-bold">{{ $player->weight }} kg</span>
+                            </li>
+                            @endif
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-star me-2"></i>Rating</span>
+                                <span class="fw-bold">{{ number_format($player->rating, 1) }}/5.0</span>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+
+                <!-- Player Statistics -->
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Career Statistics</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row text-center">
+                            <div class="col-6 mb-3">
+                                <div class="stats-number text-primary">{{ $player_stats['matches_played'] }}</div>
+                                <div class="stats-label">Matches</div>
+                            </div>
+                            <div class="col-6 mb-3">
+                                <div class="stats-number text-primary">{{ $player_stats['goals'] }}</div>
+                                <div class="stats-label">Goals</div>
+                            </div>
+                            <div class="col-6 mb-3">
+                                <div class="stats-number text-primary">{{ $player_stats['assists'] }}</div>
+                                <div class="stats-label">Assists</div>
+                            </div>
+                            <div class="col-6 mb-3">
+                                <div class="stats-number text-primary">{{ $player_stats['clean_sheets'] }}</div>
+                                <div class="stats-label">Clean Sheets</div>
+                            </div>
+                            <div class="col-6">
+                                <div class="stats-number text-warning">{{ $player_stats['yellow_cards'] }}</div>
+                                <div class="stats-label">Yellow Cards</div>
+                            </div>
+                            <div class="col-6">
+                                <div class="stats-number text-danger">{{ $player_stats['red_cards'] }}</div>
+                                <div class="stats-label">Red Cards</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Player Details -->
+            <div class="col-lg-8">
+                <!-- Team Information -->
+                @if($player->team)
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Current Team</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="d-flex align-items-center">
+                            @if($player->team->logo)
+                                <img src="{{ asset('storage/' . $player->team->logo) }}" alt="{{ $player->team->name }}" class="me-3" width="60" height="60" style="object-fit: contain;">
+                            @else
+                                <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $player->team->name }}" class="me-3" width="60" height="60" style="object-fit: contain;">
+                            @endif
+                            <div class="flex-grow-1">
+                                <h5 class="mb-1">{{ $player->team->name }}</h5>
+                                <p class="text-muted mb-0">
+                                    <i class="fas fa-map-marker-alt me-1"></i>{{ $player->team->city }}, {{ $player->team->country }}
+                                </p>
+                            </div>
+                            <a href="{{ route('fuma.teams.show', $player->team) }}" class="btn btn-outline-primary">
+                                <i class="fas fa-eye me-2"></i> View Team
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                @endif
+
+                <!-- Recent Match Events -->
+                @if($player->matchEvents->count() > 0)
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Recent Match Events</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Date</th>
+                                        <th>Match</th>
+                                        <th>Event</th>
+                                        <th>Minute</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($player->matchEvents->sortByDesc('created_at')->take(10) as $event)
+                                    <tr>
+                                        <td>{{ $event->match->scheduled_at->format('M d, Y') }}</td>
+                                        <td>
+                                            <a href="{{ route('fuma.matches.show', $event->match) }}" class="text-decoration-none">
+                                                {{ $event->match->homeTeam->name }} vs {{ $event->match->awayTeam->name }}
+                                            </a>
+                                        </td>
+                                        <td>
+                                            <span class="badge bg-{{ $event->type === 'goal' ? 'success' : ($event->type === 'yellow_card' ? 'warning' : 'danger') }}">
+                                                {{ ucwords(str_replace('_', ' ', $event->type)) }}
+                                            </span>
+                                        </td>
+                                        <td>{{ $event->minute }}'</td>
+                                        <td>
+                                            <a href="{{ route('fuma.matches.show', $event->match) }}" class="btn btn-sm btn-outline-primary">
+                                                <i class="fas fa-eye"></i>
+                                            </a>
+                                        </td>
+                                    </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                @else
+                <div class="card">
+                    <div class="card-body text-center py-4">
+                        <i class="fas fa-futbol fa-3x text-muted mb-3"></i>
+                        <p class="text-muted">No match events recorded yet.</p>
+                    </div>
+                </div>
+                @endif
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/fuma/teams/create.blade.php
+++ b/resources/views/fuma/teams/create.blade.php
@@ -1,0 +1,127 @@
+@extends('layouts.fuma')
+
+@section('title', 'Register Team - Football Tournament Management')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <h1 class="fw-bold mb-2">Register New Team</h1>
+                    <p class="mb-0">Add a new football team to the system</p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <a href="{{ route('fuma.teams.index') }}" class="btn btn-outline-light">
+                        <i class="fas fa-arrow-left me-2"></i> Back to Teams
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="card">
+                    <div class="card-body">
+                        <form action="{{ route('fuma.teams.store') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="name" class="form-label">Team Name <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control @error('name') is-invalid @enderror" 
+                                           id="name" name="name" value="{{ old('name') }}" required>
+                                    @error('name')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="city" class="form-label">City <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control @error('city') is-invalid @enderror" 
+                                           id="city" name="city" value="{{ old('city') }}" required>
+                                    @error('city')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="country" class="form-label">Country <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control @error('country') is-invalid @enderror" 
+                                           id="country" name="country" value="{{ old('country', 'Indonesia') }}" required>
+                                    @error('country')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="logo" class="form-label">Team Logo</label>
+                                    <input type="file" class="form-control @error('logo') is-invalid @enderror" 
+                                           id="logo" name="logo" accept="image/*">
+                                    @error('logo')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                    <div class="form-text">Max file size: 2MB. Supported formats: JPEG, PNG, JPG, GIF</div>
+                                </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="description" class="form-label">Description</label>
+                                <textarea class="form-control @error('description') is-invalid @enderror" 
+                                          id="description" name="description" rows="3">{{ old('description') }}</textarea>
+                                @error('description')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <h5 class="fw-bold mb-3 mt-4">Manager Information</h5>
+                            
+                            <div class="row">
+                                <div class="col-md-4 mb-3">
+                                    <label for="manager_name" class="form-label">Manager Name</label>
+                                    <input type="text" class="form-control @error('manager_name') is-invalid @enderror" 
+                                           id="manager_name" name="manager_name" value="{{ old('manager_name') }}">
+                                    @error('manager_name')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-4 mb-3">
+                                    <label for="manager_phone" class="form-label">Manager Phone</label>
+                                    <input type="tel" class="form-control @error('manager_phone') is-invalid @enderror" 
+                                           id="manager_phone" name="manager_phone" value="{{ old('manager_phone') }}">
+                                    @error('manager_phone')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-4 mb-3">
+                                    <label for="manager_email" class="form-label">Manager Email</label>
+                                    <input type="email" class="form-control @error('manager_email') is-invalid @enderror" 
+                                           id="manager_email" name="manager_email" value="{{ old('manager_email') }}">
+                                    @error('manager_email')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="d-flex gap-2">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-save me-2"></i> Register Team
+                                </button>
+                                <a href="{{ route('fuma.teams.index') }}" class="btn btn-outline-secondary">
+                                    <i class="fas fa-times me-2"></i> Cancel
+                                </a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/fuma/teams/index.blade.php
+++ b/resources/views/fuma/teams/index.blade.php
@@ -1,0 +1,134 @@
+@extends('layouts.fuma')
+
+@section('title', 'All Teams - Football Tournament Management')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <h1 class="fw-bold mb-2">All Teams</h1>
+                    <p class="mb-0">Browse and manage football teams</p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <div class="d-flex gap-2 justify-content-md-end">
+                        <a href="{{ route('fuma.teams.create') }}" class="btn btn-light">
+                            <i class="fas fa-plus me-2"></i> Register Team
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <!-- Filters -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card filter-card">
+                    <div class="card-body">
+                        <form method="GET" action="{{ route('fuma.teams.index') }}">
+                            <div class="row g-3">
+                                <div class="col-md-3">
+                                    <label for="city" class="form-label">City</label>
+                                    <select class="form-select" id="city" name="city">
+                                        <option value="">All Cities</option>
+                                        @foreach($cities as $city)
+                                            <option value="{{ $city }}" {{ request('city') === $city ? 'selected' : '' }}>{{ $city }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="search" class="form-label">Search</label>
+                                    <input type="text" class="form-control" id="search" name="search" 
+                                           placeholder="Team name..." value="{{ request('search') }}">
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="sort" class="form-label">Sort By</label>
+                                    <select class="form-select" id="sort" name="sort">
+                                        <option value="name" {{ request('sort') === 'name' ? 'selected' : '' }}>Name</option>
+                                        <option value="rating" {{ request('sort') === 'rating' ? 'selected' : '' }}>Rating</option>
+                                        <option value="city" {{ request('sort') === 'city' ? 'selected' : '' }}>City</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-3 d-flex align-items-end">
+                                    <button type="submit" class="btn btn-primary me-2">
+                                        <i class="fas fa-search me-1"></i> Filter
+                                    </button>
+                                    <a href="{{ route('fuma.teams.index') }}" class="btn btn-outline-secondary">
+                                        <i class="fas fa-undo me-1"></i> Reset
+                                    </a>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Teams Grid -->
+        <div class="row g-4">
+            @forelse($teams as $team)
+            <div class="col-lg-4 col-md-6">
+                <div class="card h-100">
+                    <div class="card-body text-center">
+                        @if($team->logo)
+                            <img src="{{ asset('storage/' . $team->logo) }}" alt="{{ $team->name }}" class="mb-3" width="80" height="80" style="object-fit: contain;">
+                        @else
+                            <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $team->name }}" class="mb-3" width="80" height="80" style="object-fit: contain;">
+                        @endif
+                        <h5 class="card-title">{{ $team->name }}</h5>
+                        <p class="text-muted mb-2">
+                            <i class="fas fa-map-marker-alt me-1"></i> {{ $team->city }}
+                        </p>
+                        @if($team->description)
+                            <p class="card-text small text-muted">{{ Str::limit($team->description, 80) }}</p>
+                        @endif
+                        <div class="d-flex justify-content-center gap-2 mb-3">
+                            <span class="badge bg-light text-dark">
+                                <i class="fas fa-users me-1"></i> {{ $team->players->count() }} players
+                            </span>
+                            <span class="badge bg-light text-dark">
+                                <i class="fas fa-star text-warning me-1"></i> {{ number_format($team->rating, 1) }}
+                            </span>
+                            @if($team->trophies_count > 0)
+                                <span class="badge bg-light text-dark">
+                                    <i class="fas fa-trophy text-warning me-1"></i> {{ $team->trophies_count }}
+                                </span>
+                            @endif
+                        </div>
+                        <div class="d-flex gap-2">
+                            <a href="{{ route('fuma.teams.show', $team) }}" class="btn btn-sm btn-outline-primary flex-fill">
+                                <i class="fas fa-eye me-1"></i> View Team
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            @empty
+            <div class="col-12 text-center py-5">
+                <div class="text-muted">
+                    <i class="fas fa-users fa-3x mb-3"></i>
+                    <p>No teams found matching your criteria.</p>
+                    <a href="{{ route('fuma.teams.create') }}" class="btn btn-primary">
+                        <i class="fas fa-plus me-2"></i> Register First Team
+                    </a>
+                </div>
+            </div>
+            @endforelse
+        </div>
+
+        <!-- Pagination -->
+        @if($teams->hasPages())
+        <div class="row mt-4">
+            <div class="col-12">
+                <div class="d-flex justify-content-center">
+                    {{ $teams->links() }}
+                </div>
+            </div>
+        </div>
+        @endif
+    </div>
+@endsection

--- a/resources/views/fuma/teams/show.blade.php
+++ b/resources/views/fuma/teams/show.blade.php
@@ -1,0 +1,287 @@
+@extends('layouts.fuma')
+
+@section('title', $team->name . ' - Team Details')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-8">
+                    <div class="d-flex align-items-center">
+                        @if($team->logo)
+                            <img src="{{ asset('storage/' . $team->logo) }}" alt="{{ $team->name }}" class="me-3" width="80" height="80" style="object-fit: contain;">
+                        @else
+                            <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $team->name }}" class="me-3" width="80" height="80" style="object-fit: contain;">
+                        @endif
+                        <div>
+                            <h1 class="fw-bold mb-1">{{ $team->name }}</h1>
+                            <p class="mb-0">
+                                <i class="fas fa-map-marker-alt me-2"></i>{{ $team->city }}, {{ $team->country }}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <div class="d-flex gap-2 justify-content-md-end">
+                        @if(auth()->check())
+                            <button class="btn btn-light">
+                                <i class="fas fa-edit me-2"></i> Edit Team
+                            </button>
+                        @endif
+                        <a href="{{ route('fuma.teams.index') }}" class="btn btn-outline-light">
+                            <i class="fas fa-arrow-left me-2"></i> Back to Teams
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <div class="row">
+            <!-- Team Information -->
+            <div class="col-lg-4">
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Team Information</h5>
+                    </div>
+                    <div class="card-body">
+                        @if($team->description)
+                            <p class="mb-3">{{ $team->description }}</p>
+                        @endif
+                        <ul class="list-group list-group-flush">
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-map-marker-alt me-2"></i>City</span>
+                                <span class="fw-bold">{{ $team->city }}</span>
+                            </li>
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-flag me-2"></i>Country</span>
+                                <span class="fw-bold">{{ $team->country }}</span>
+                            </li>
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-users me-2"></i>Players</span>
+                                <span class="fw-bold">{{ $team->players->count() }}</span>
+                            </li>
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-star me-2"></i>Rating</span>
+                                <span class="fw-bold">{{ number_format($team->rating, 1) }}/5.0</span>
+                            </li>
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-trophy me-2"></i>Trophies</span>
+                                <span class="fw-bold">{{ $team->trophies_count }}</span>
+                            </li>
+                            @if($team->manager_name)
+                            <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                                <span class="text-muted"><i class="fas fa-user-tie me-2"></i>Manager</span>
+                                <span class="fw-bold">{{ $team->manager_name }}</span>
+                            </li>
+                            @endif
+                        </ul>
+                    </div>
+                </div>
+
+                <!-- Team Statistics -->
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Team Statistics</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row text-center">
+                            <div class="col-6 mb-3">
+                                <div class="stats-number text-primary">{{ $team_stats['total_matches'] }}</div>
+                                <div class="stats-label">Matches</div>
+                            </div>
+                            <div class="col-6 mb-3">
+                                <div class="stats-number text-primary">{{ $team_stats['wins'] }}</div>
+                                <div class="stats-label">Wins</div>
+                            </div>
+                            <div class="col-6 mb-3">
+                                <div class="stats-number text-primary">{{ $team_stats['draws'] }}</div>
+                                <div class="stats-label">Draws</div>
+                            </div>
+                            <div class="col-6 mb-3">
+                                <div class="stats-number text-primary">{{ $team_stats['losses'] }}</div>
+                                <div class="stats-label">Losses</div>
+                            </div>
+                            <div class="col-6">
+                                <div class="stats-number text-primary">{{ $team_stats['goals_for'] }}</div>
+                                <div class="stats-label">Goals For</div>
+                            </div>
+                            <div class="col-6">
+                                <div class="stats-number text-primary">{{ $team_stats['goals_against'] }}</div>
+                                <div class="stats-label">Goals Against</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Players Roster -->
+            <div class="col-lg-8">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h5 class="card-title mb-0">Players Roster</h5>
+                        @if(auth()->check())
+                            <a href="{{ route('fuma.players.create', ['team_id' => $team->id]) }}" class="btn btn-sm btn-primary">
+                                <i class="fas fa-plus me-2"></i> Add Player
+                            </a>
+                        @endif
+                    </div>
+                    <div class="card-body">
+                        @if($team->players->count() > 0)
+                            <div class="table-responsive">
+                                <table class="table table-hover mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>#</th>
+                                            <th>Player</th>
+                                            <th>Position</th>
+                                            <th>Age</th>
+                                            <th>Goals</th>
+                                            <th>Assists</th>
+                                            <th>Rating</th>
+                                            <th>Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach($team->players->sortBy('jersey_number') as $player)
+                                        <tr>
+                                            <td>
+                                                @if($player->jersey_number)
+                                                    <span class="badge bg-primary">#{{ $player->jersey_number }}</span>
+                                                @else
+                                                    <span class="text-muted">-</span>
+                                                @endif
+                                            </td>
+                                            <td>
+                                                <div class="d-flex align-items-center">
+                                                    @if($player->avatar)
+                                                        <img src="{{ asset('storage/' . $player->avatar) }}" alt="{{ $player->name }}" class="rounded-circle me-2" width="32" height="32" style="object-fit: cover;">
+                                                    @else
+                                                        <img src="https://ui-avatars.com/api/?name={{ urlencode($player->name) }}&size=32&background=2563eb&color=fff" alt="{{ $player->name }}" class="rounded-circle me-2" width="32" height="32">
+                                                    @endif
+                                                    <span>{{ $player->name }}</span>
+                                                </div>
+                                            </td>
+                                            <td>{{ $player->position }}</td>
+                                            <td>{{ $player->age ?: '-' }}</td>
+                                            <td>{{ $player->goals_scored }}</td>
+                                            <td>{{ $player->assists }}</td>
+                                            <td>
+                                                <span class="badge bg-light text-dark">
+                                                    <i class="fas fa-star text-warning me-1"></i>{{ number_format($player->rating, 1) }}
+                                                </span>
+                                            </td>
+                                            <td>
+                                                <a href="{{ route('fuma.players.show', $player) }}" class="btn btn-sm btn-outline-primary">
+                                                    <i class="fas fa-eye"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        @else
+                            <div class="text-center py-4">
+                                <i class="fas fa-user-circle fa-3x text-muted mb-3"></i>
+                                <p class="text-muted">No players registered for this team yet.</p>
+                                @if(auth()->check())
+                                    <a href="{{ route('fuma.players.create', ['team_id' => $team->id]) }}" class="btn btn-primary">
+                                        <i class="fas fa-plus me-2"></i> Add First Player
+                                    </a>
+                                @endif
+                            </div>
+                        @endif
+                    </div>
+                </div>
+
+                <!-- Recent Matches -->
+                @if($team->getAllMatchesAttribute()->count() > 0)
+                <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Recent Matches</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Date</th>
+                                        <th>Tournament</th>
+                                        <th>Opponent</th>
+                                        <th>Score</th>
+                                        <th>Result</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($team->getAllMatchesAttribute()->sortByDesc('scheduled_at')->take(5) as $match)
+                                    <tr>
+                                        <td>{{ $match->scheduled_at->format('M d, Y') }}</td>
+                                        <td>
+                                            <a href="{{ route('fuma.tournaments.show', $match->tournament) }}" class="text-decoration-none">
+                                                {{ $match->tournament->name }}
+                                            </a>
+                                        </td>
+                                        <td>
+                                            @php
+                                                $opponent = $match->home_team_id === $team->id ? $match->awayTeam : $match->homeTeam;
+                                                $isHome = $match->home_team_id === $team->id;
+                                            @endphp
+                                            <div class="d-flex align-items-center">
+                                                @if($opponent->logo)
+                                                    <img src="{{ asset('storage/' . $opponent->logo) }}" alt="{{ $opponent->name }}" class="team-logo-sm me-2">
+                                                @else
+                                                    <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $opponent->name }}" class="team-logo-sm me-2">
+                                                @endif
+                                                <span>{{ $opponent->name }} {{ $isHome ? '(A)' : '(H)' }}</span>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            @if($match->status === 'completed')
+                                                @php
+                                                    $teamScore = $isHome ? $match->home_score : $match->away_score;
+                                                    $opponentScore = $isHome ? $match->away_score : $match->home_score;
+                                                @endphp
+                                                <span class="match-score">{{ $teamScore }} - {{ $opponentScore }}</span>
+                                            @else
+                                                <span class="text-muted">{{ ucfirst($match->status) }}</span>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            @if($match->status === 'completed')
+                                                @php
+                                                    $teamScore = $isHome ? $match->home_score : $match->away_score;
+                                                    $opponentScore = $isHome ? $match->away_score : $match->home_score;
+                                                @endphp
+                                                @if($teamScore > $opponentScore)
+                                                    <span class="badge bg-success">W</span>
+                                                @elseif($teamScore < $opponentScore)
+                                                    <span class="badge bg-danger">L</span>
+                                                @else
+                                                    <span class="badge bg-warning">D</span>
+                                                @endif
+                                            @else
+                                                <span class="badge bg-secondary">-</span>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('fuma.matches.show', $match) }}" class="btn btn-sm btn-outline-primary">
+                                                <i class="fas fa-eye"></i>
+                                            </a>
+                                        </td>
+                                    </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                @endif
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/fuma/tournaments/create.blade.php
+++ b/resources/views/fuma/tournaments/create.blade.php
@@ -1,0 +1,133 @@
+@extends('layouts.fuma')
+
+@section('title', 'Create Tournament - Football Tournament Management')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <h1 class="fw-bold mb-2">Create New Tournament</h1>
+                    <p class="mb-0">Set up a new football tournament</p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <a href="{{ route('fuma.tournaments.index') }}" class="btn btn-outline-light">
+                        <i class="fas fa-arrow-left me-2"></i> Back to Tournaments
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="card">
+                    <div class="card-body">
+                        <form action="{{ route('fuma.tournaments.store') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="name" class="form-label">Tournament Name <span class="text-danger">*</span></label>
+                                    <input type="text" class="form-control @error('name') is-invalid @enderror" 
+                                           id="name" name="name" value="{{ old('name') }}" required>
+                                    @error('name')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="venue" class="form-label">Venue</label>
+                                    <input type="text" class="form-control @error('venue') is-invalid @enderror" 
+                                           id="venue" name="venue" value="{{ old('venue') }}">
+                                    @error('venue')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="description" class="form-label">Description</label>
+                                <textarea class="form-control @error('description') is-invalid @enderror" 
+                                          id="description" name="description" rows="3">{{ old('description') }}</textarea>
+                                @error('description')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="start_date" class="form-label">Start Date <span class="text-danger">*</span></label>
+                                    <input type="date" class="form-control @error('start_date') is-invalid @enderror" 
+                                           id="start_date" name="start_date" value="{{ old('start_date') }}" required>
+                                    @error('start_date')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="end_date" class="form-label">End Date <span class="text-danger">*</span></label>
+                                    <input type="date" class="form-control @error('end_date') is-invalid @enderror" 
+                                           id="end_date" name="end_date" value="{{ old('end_date') }}" required>
+                                    @error('end_date')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label for="max_teams" class="form-label">Maximum Teams <span class="text-danger">*</span></label>
+                                    <select class="form-select @error('max_teams') is-invalid @enderror" id="max_teams" name="max_teams" required>
+                                        <option value="">Select maximum teams</option>
+                                        <option value="4" {{ old('max_teams') == '4' ? 'selected' : '' }}>4 Teams</option>
+                                        <option value="8" {{ old('max_teams') == '8' ? 'selected' : '' }}>8 Teams</option>
+                                        <option value="16" {{ old('max_teams') == '16' ? 'selected' : '' }}>16 Teams</option>
+                                        <option value="32" {{ old('max_teams') == '32' ? 'selected' : '' }}>32 Teams</option>
+                                    </select>
+                                    @error('max_teams')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
+                                <div class="col-md-6 mb-3">
+                                    <label for="logo" class="form-label">Tournament Logo</label>
+                                    <input type="file" class="form-control @error('logo') is-invalid @enderror" 
+                                           id="logo" name="logo" accept="image/*">
+                                    @error('logo')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                    <div class="form-text">Max file size: 2MB. Supported formats: JPEG, PNG, JPG, GIF</div>
+                                </div>
+                            </div>
+
+                            <div class="d-flex gap-2">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-save me-2"></i> Create Tournament
+                                </button>
+                                <a href="{{ route('fuma.tournaments.index') }}" class="btn btn-outline-secondary">
+                                    <i class="fas fa-times me-2"></i> Cancel
+                                </a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+document.getElementById('start_date').addEventListener('change', function() {
+    const startDate = this.value;
+    const endDateInput = document.getElementById('end_date');
+    if (startDate) {
+        endDateInput.min = startDate;
+    }
+});
+</script>
+@endpush

--- a/resources/views/fuma/tournaments/index.blade.php
+++ b/resources/views/fuma/tournaments/index.blade.php
@@ -1,0 +1,148 @@
+@extends('layouts.fuma')
+
+@section('title', 'All Tournaments - Football Tournament Management')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row">
+                <div class="col-md-8">
+                    <h1 class="fw-bold mb-2">All Tournaments</h1>
+                    <p class="mb-0">Manage and view all football tournaments</p>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <div class="d-flex gap-2 justify-content-md-end">
+                        <a href="{{ route('fuma.tournaments.create') }}" class="btn btn-light">
+                            <i class="fas fa-plus me-2"></i> Create Tournament
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="container">
+        <!-- Filters -->
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card filter-card">
+                    <div class="card-body">
+                        <form method="GET" action="{{ route('fuma.tournaments.index') }}">
+                            <div class="row g-3">
+                                <div class="col-md-3">
+                                    <label for="status" class="form-label">Status</label>
+                                    <select class="form-select" id="status" name="status">
+                                        <option value="">All Status</option>
+                                        <option value="upcoming" {{ request('status') === 'upcoming' ? 'selected' : '' }}>Upcoming</option>
+                                        <option value="ongoing" {{ request('status') === 'ongoing' ? 'selected' : '' }}>Active</option>
+                                        <option value="completed" {{ request('status') === 'completed' ? 'selected' : '' }}>Completed</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="search" class="form-label">Search</label>
+                                    <input type="text" class="form-control" id="search" name="search" 
+                                           placeholder="Tournament name..." value="{{ request('search') }}">
+                                </div>
+                                <div class="col-md-3">
+                                    <label for="date_from" class="form-label">Start Date From</label>
+                                    <input type="date" class="form-control" id="date_from" name="date_from" value="{{ request('date_from') }}">
+                                </div>
+                                <div class="col-md-3 d-flex align-items-end">
+                                    <button type="submit" class="btn btn-primary me-2">
+                                        <i class="fas fa-search me-1"></i> Filter
+                                    </button>
+                                    <a href="{{ route('fuma.tournaments.index') }}" class="btn btn-outline-secondary">
+                                        <i class="fas fa-undo me-1"></i> Reset
+                                    </a>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Tournaments Table -->
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Name</th>
+                                        <th>Start Date</th>
+                                        <th>End Date</th>
+                                        <th>Teams</th>
+                                        <th>Venue</th>
+                                        <th>Status</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse($tournaments as $tournament)
+                                    <tr>
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                @if($tournament->logo)
+                                                    <img src="{{ asset('storage/' . $tournament->logo) }}" alt="{{ $tournament->name }}" class="rounded-circle me-3" width="40" height="40">
+                                                @else
+                                                    <img src="https://tse1.mm.bing.net/th/id/OIP.MaIk4N5rw51_K6gHkokGUgHaGl?pid=Api" alt="{{ $tournament->name }}" class="rounded-circle me-3" width="40" height="40">
+                                                @endif
+                                                <div>
+                                                    <h6 class="mb-0">{{ $tournament->name }}</h6>
+                                                    <small class="text-muted">{{ Str::limit($tournament->description, 50) }}</small>
+                                                </div>
+                                            </div>
+                                        </td>
+                                        <td>{{ $tournament->start_date->format('Y-m-d') }}</td>
+                                        <td>{{ $tournament->end_date->format('Y-m-d') }}</td>
+                                        <td>{{ $tournament->teams->count() }}/{{ $tournament->max_teams }}</td>
+                                        <td>{{ $tournament->venue ?: 'TBD' }}</td>
+                                        <td>
+                                            <span class="status-badge badge-{{ $tournament->status === 'ongoing' ? 'active' : $tournament->status }}">
+                                                {{ ucfirst($tournament->status) }}
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('fuma.tournaments.show', $tournament) }}" class="btn btn-sm btn-outline-primary action-btn">
+                                                <i class="fas fa-eye"></i> View
+                                            </a>
+                                        </td>
+                                    </tr>
+                                    @empty
+                                    <tr>
+                                        <td colspan="7" class="text-center py-4">
+                                            <div class="text-muted">
+                                                <i class="fas fa-trophy fa-3x mb-3"></i>
+                                                <p>No tournaments found matching your criteria.</p>
+                                                <a href="{{ route('fuma.tournaments.create') }}" class="btn btn-primary">
+                                                    <i class="fas fa-plus me-2"></i> Create First Tournament
+                                                </a>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Pagination -->
+        @if($tournaments->hasPages())
+        <div class="row mt-4">
+            <div class="col-12">
+                <div class="d-flex justify-content-center">
+                    {{ $tournaments->links() }}
+                </div>
+            </div>
+        </div>
+        @endif
+    </div>
+@endsection

--- a/resources/views/fuma/tournaments/show.blade.php
+++ b/resources/views/fuma/tournaments/show.blade.php
@@ -1,0 +1,442 @@
+@extends('layouts.fuma')
+
+@section('title', $tournament->name . ' - Tournament Details')
+
+@section('content')
+    <!-- Page Header -->
+    <div class="page-header">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-8">
+                    <div class="d-flex align-items-center">
+                        @if($tournament->logo)
+                            <img src="{{ asset('storage/' . $tournament->logo) }}" alt="{{ $tournament->name }}" class="rounded-circle me-3" width="60" height="60">
+                        @else
+                            <img src="https://tse1.mm.bing.net/th/id/OIP.MaIk4N5rw51_K6gHkokGUgHaGl?pid=Api" alt="{{ $tournament->name }}" class="rounded-circle me-3" width="60" height="60">
+                        @endif
+                        <div>
+                            <h1 class="fw-bold mb-1">{{ $tournament->name }}</h1>
+                            <p class="mb-0">{{ $tournament->description }}</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <div class="d-flex gap-2 justify-content-md-end">
+                        @if(auth()->check())
+                            <button class="btn btn-light me-2" data-bs-toggle="modal" data-bs-target="#editTournamentModal">
+                                <i class="fas fa-edit me-2"></i> Edit
+                            </button>
+                            <div class="dropdown">
+                                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                                    <i class="fas fa-cog me-2"></i> Manage
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#addTeamModal">
+                                        <i class="fas fa-plus me-2"></i>Add Team
+                                    </a></li>
+                                    <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#scheduleMatchModal">
+                                        <i class="fas fa-calendar-plus me-2"></i>Schedule Match
+                                    </a></li>
+                                    <li><hr class="dropdown-divider"></li>
+                                    <li><a class="dropdown-item text-danger" href="#" onclick="confirmDelete('{{ $tournament->id }}')">
+                                        <i class="fas fa-trash me-2"></i>Delete Tournament
+                                    </a></li>
+                                </ul>
+                            </div>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Navigation Tabs -->
+    <div class="container">
+        <ul class="nav nav-tabs mb-4" id="tournamentTabs">
+            <li class="nav-item">
+                <button class="nav-link active" id="overview-tab" data-bs-toggle="tab" data-bs-target="#overview" type="button">
+                    <i class="fas fa-info-circle me-2"></i> Overview
+                </button>
+            </li>
+            <li class="nav-item">
+                <button class="nav-link" id="standings-tab" data-bs-toggle="tab" data-bs-target="#standings" type="button">
+                    <i class="fas fa-trophy me-2"></i> Standings
+                </button>
+            </li>
+            <li class="nav-item">
+                <button class="nav-link" id="matches-tab" data-bs-toggle="tab" data-bs-target="#matches" type="button">
+                    <i class="fas fa-futbol me-2"></i> Matches
+                </button>
+            </li>
+            <li class="nav-item">
+                <button class="nav-link" id="teams-tab" data-bs-toggle="tab" data-bs-target="#teams" type="button">
+                    <i class="fas fa-users me-2"></i> Teams
+                </button>
+            </li>
+            <li class="nav-item">
+                <button class="nav-link" id="stats-tab" data-bs-toggle="tab" data-bs-target="#stats" type="button">
+                    <i class="fas fa-chart-bar me-2"></i> Statistics
+                </button>
+            </li>
+        </ul>
+
+        <!-- Tab Content -->
+        <div class="tab-content" id="tournamentTabsContent">
+            <!-- Overview Tab -->
+            <div class="tab-pane fade show active" id="overview" role="tabpanel">
+                <div class="row">
+                    <div class="col-lg-8">
+                        <div class="card">
+                            <div class="card-header">
+                                <h5 class="card-title mb-0">Tournament Information</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <p><strong>Start Date:</strong> {{ $tournament->start_date->format('F d, Y') }}</p>
+                                        <p><strong>End Date:</strong> {{ $tournament->end_date->format('F d, Y') }}</p>
+                                        <p><strong>Venue:</strong> {{ $tournament->venue ?: 'TBD' }}</p>
+                                        <p><strong>Max Teams:</strong> {{ $tournament->max_teams }}</p>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <p><strong>Status:</strong> 
+                                            <span class="status-badge badge-{{ $tournament->status === 'ongoing' ? 'active' : $tournament->status }}">
+                                                {{ ucfirst($tournament->status) }}
+                                            </span>
+                                        </p>
+                                        <p><strong>Registered Teams:</strong> {{ $tournament->teams->count() }}</p>
+                                        <p><strong>Organizer:</strong> {{ $tournament->organizer->name }}</p>
+                                    </div>
+                                </div>
+                                @if($tournament->description)
+                                    <hr>
+                                    <p><strong>Description:</strong></p>
+                                    <p>{{ $tournament->description }}</p>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-4">
+                        <div class="card">
+                            <div class="card-header">
+                                <h5 class="card-title mb-0">Quick Stats</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="row text-center">
+                                    <div class="col-6 mb-3">
+                                        <div class="stats-number text-primary">{{ $tournament->teams->count() }}</div>
+                                        <div class="stats-label">Teams</div>
+                                    </div>
+                                    <div class="col-6 mb-3">
+                                        <div class="stats-number text-primary">{{ $tournament->matches->count() }}</div>
+                                        <div class="stats-label">Matches</div>
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="stats-number text-primary">{{ $tournament->matches->where('status', 'completed')->count() }}</div>
+                                        <div class="stats-label">Completed</div>
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="stats-number text-primary">{{ $tournament->matches->where('status', 'scheduled')->count() }}</div>
+                                        <div class="stats-label">Upcoming</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Standings Tab -->
+            <div class="tab-pane fade" id="standings" role="tabpanel">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Tournament Standings</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Pos</th>
+                                        <th>Team</th>
+                                        <th>MP</th>
+                                        <th>W</th>
+                                        <th>D</th>
+                                        <th>L</th>
+                                        <th>GF</th>
+                                        <th>GA</th>
+                                        <th>GD</th>
+                                        <th>Pts</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse($tournament->standings as $index => $team)
+                                    <tr>
+                                        <td>{{ $index + 1 }}</td>
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                @if($team->logo)
+                                                    <img src="{{ asset('storage/' . $team->logo) }}" alt="{{ $team->name }}" class="team-logo-sm me-2">
+                                                @else
+                                                    <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $team->name }}" class="team-logo-sm me-2">
+                                                @endif
+                                                <span>{{ $team->name }}</span>
+                                            </div>
+                                        </td>
+                                        <td>{{ $team->pivot->matches_played }}</td>
+                                        <td>{{ $team->pivot->wins }}</td>
+                                        <td>{{ $team->pivot->draws }}</td>
+                                        <td>{{ $team->pivot->losses }}</td>
+                                        <td>{{ $team->pivot->goals_for }}</td>
+                                        <td>{{ $team->pivot->goals_against }}</td>
+                                        <td>{{ $team->pivot->goal_difference }}</td>
+                                        <td><strong>{{ $team->pivot->points }}</strong></td>
+                                    </tr>
+                                    @empty
+                                    <tr>
+                                        <td colspan="10" class="text-center py-4">
+                                            <p class="text-muted">No teams registered yet.</p>
+                                        </td>
+                                    </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Matches Tab -->
+            <div class="tab-pane fade" id="matches" role="tabpanel">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Tournament Matches</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Date</th>
+                                        <th>Stage</th>
+                                        <th>Home Team</th>
+                                        <th>Score</th>
+                                        <th>Away Team</th>
+                                        <th>Venue</th>
+                                        <th>Status</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse($tournament->matches as $match)
+                                    <tr>
+                                        <td>{{ $match->scheduled_at->format('M d, H:i') }}</td>
+                                        <td>
+                                            <span class="badge bg-primary">{{ ucwords(str_replace('_', ' ', $match->stage)) }}</span>
+                                        </td>
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                @if($match->homeTeam->logo)
+                                                    <img src="{{ asset('storage/' . $match->homeTeam->logo) }}" alt="{{ $match->homeTeam->name }}" class="team-logo-sm me-2">
+                                                @else
+                                                    <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $match->homeTeam->name }}" class="team-logo-sm me-2">
+                                                @endif
+                                                <span>{{ $match->homeTeam->name }}</span>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            @if($match->status === 'completed')
+                                                <span class="match-score">{{ $match->home_score }} - {{ $match->away_score }}</span>
+                                            @elseif($match->status === 'live')
+                                                <span class="badge bg-danger live-badge">LIVE</span>
+                                            @else
+                                                <span class="text-muted">vs</span>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                @if($match->awayTeam->logo)
+                                                    <img src="{{ asset('storage/' . $match->awayTeam->logo) }}" alt="{{ $match->awayTeam->name }}" class="team-logo-sm me-2">
+                                                @else
+                                                    <img src="https://tse2.mm.bing.net/th/id/OIP.lpgOZ4hPNpsQjk22cDyIegHaFf?pid=Api&P=0&h=180" alt="{{ $match->awayTeam->name }}" class="team-logo-sm me-2">
+                                                @endif
+                                                <span>{{ $match->awayTeam->name }}</span>
+                                            </div>
+                                        </td>
+                                        <td>{{ $match->venue ?: 'TBD' }}</td>
+                                        <td>
+                                            <span class="badge bg-{{ $match->status === 'live' ? 'danger' : ($match->status === 'completed' ? 'success' : 'warning') }}">
+                                                {{ ucfirst($match->status) }}
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('fuma.matches.show', $match) }}" class="btn btn-sm btn-outline-primary action-btn">
+                                                <i class="fas fa-eye"></i> View
+                                            </a>
+                                        </td>
+                                    </tr>
+                                    @empty
+                                    <tr>
+                                        <td colspan="8" class="text-center py-4">
+                                            <p class="text-muted">No matches scheduled yet.</p>
+                                        </td>
+                                    </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Teams Tab -->
+            <div class="tab-pane fade" id="teams" role="tabpanel">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">Participating Teams</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Team</th>
+                                        <th>City</th>
+                                        <th>Manager</th>
+                                        <th>Players</th>
+                                        <th>Rating</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse($tournament->teams as $team)
+                                    <tr>
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                @if($team->logo)
+                                                    <img src="{{ asset('storage/' . $team->logo) }}" alt="{{ $team->name }}" class="team-logo-sm me-2">
+                                                @else
+                                                    <img src="https://tse4.mm.bing.net/th/id/OIP.4eLwPDOhLiS4DWexutPB7AHaEK?pid=Api&P=0&h=180" alt="{{ $team->name }}" class="team-logo-sm me-2">
+                                                @endif
+                                                <span>{{ $team->name }}</span>
+                                            </div>
+                                        </td>
+                                        <td>{{ $team->city }}</td>
+                                        <td>{{ $team->manager_name ?: 'TBD' }}</td>
+                                        <td>{{ $team->players->count() }}</td>
+                                        <td>
+                                            <span class="badge bg-light text-dark">
+                                                <i class="fas fa-star text-warning me-1"></i>{{ number_format($team->rating, 1) }}
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('fuma.teams.show', $team) }}" class="btn btn-sm btn-outline-primary">View Team</a>
+                                        </td>
+                                    </tr>
+                                    @empty
+                                    <tr>
+                                        <td colspan="6" class="text-center py-4">
+                                            <p class="text-muted">No teams registered yet.</p>
+                                        </td>
+                                    </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Statistics Tab -->
+            <div class="tab-pane fade" id="stats" role="tabpanel">
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header">
+                                <h5 class="card-title mb-0">Top Scorers</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="list-group list-group-flush">
+                                    @forelse($tournament->topScorers ?? [] as $player)
+                                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                                        <div class="d-flex align-items-center">
+                                            @if($player->avatar)
+                                                <img src="{{ asset('storage/' . $player->avatar) }}" alt="{{ $player->name }}" class="rounded-circle me-2" width="30" height="30">
+                                            @else
+                                                <img src="https://ui-avatars.com/api/?name={{ urlencode($player->name) }}&size=30&background=2563eb&color=fff" alt="{{ $player->name }}" class="rounded-circle me-2" width="30" height="30">
+                                            @endif
+                                            <div>
+                                                <strong>{{ $player->name }}</strong><br>
+                                                <small class="text-muted">{{ $player->team->name ?? 'No Team' }}</small>
+                                            </div>
+                                        </div>
+                                        <span class="badge bg-primary">{{ $player->goals_scored }} goals</span>
+                                    </div>
+                                    @empty
+                                    <div class="text-center py-3">
+                                        <p class="text-muted">No goals scored yet.</p>
+                                    </div>
+                                    @endforelse
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header">
+                                <h5 class="card-title mb-0">Match Statistics</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="row text-center">
+                                    <div class="col-6 mb-3">
+                                        <div class="stats-number text-primary">{{ $tournament->matches->sum('home_score') + $tournament->matches->sum('away_score') }}</div>
+                                        <div class="stats-label">Total Goals</div>
+                                    </div>
+                                    <div class="col-6 mb-3">
+                                        <div class="stats-number text-primary">{{ $tournament->matches->where('status', 'completed')->count() }}</div>
+                                        <div class="stats-label">Matches Played</div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div class="stats-number text-primary">
+                                            {{ $tournament->matches->where('status', 'completed')->count() > 0 ? 
+                                               number_format(($tournament->matches->sum('home_score') + $tournament->matches->sum('away_score')) / $tournament->matches->where('status', 'completed')->count(), 1) : 0 }}
+                                        </div>
+                                        <div class="stats-label">Goals per Match</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+function confirmDelete(tournamentId) {
+    if (confirm('Are you sure you want to delete this tournament? This action cannot be undone.')) {
+        // Create a form to submit DELETE request
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = `/fuma/tournaments/${tournamentId}`;
+        
+        const methodInput = document.createElement('input');
+        methodInput.type = 'hidden';
+        methodInput.name = '_method';
+        methodInput.value = 'DELETE';
+        
+        const tokenInput = document.createElement('input');
+        tokenInput.type = 'hidden';
+        tokenInput.name = '_token';
+        tokenInput.value = '{{ csrf_token() }}';
+        
+        form.appendChild(methodInput);
+        form.appendChild(tokenInput);
+        document.body.appendChild(form);
+        form.submit();
+    }
+}
+</script>
+@endpush

--- a/resources/views/layouts/fuma.blade.php
+++ b/resources/views/layouts/fuma.blade.php
@@ -1,0 +1,403 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title', 'Football Tournament Management')</title>
+    <!-- Bootstrap 5 CSS CDN -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Animate.css -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
+    
+    <style>
+        :root {
+            --primary-color: #2563eb;       /* New primary (lighter blue from gradient) */
+            --secondary-color: #1e40af;    /* New secondary (darker blue from gradient) */
+            --accent-color: #e74c3c;       /* Keeping the original accent color (red) */
+            --light-color: #f8fafc;        /* Lighter background color */
+            --dark-color: #1e293b;         /* Darker text color that complements the blues */
+            
+            /* Optional: You can add gradient variables if you'll reuse them */
+            --blue-gradient: linear-gradient(135deg, #1e40af, #2563eb);
+        }
+        
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: #f8f9fa;
+            color: var(--dark-color);
+        }
+        
+        .navbar {
+            background-color: var(--secondary-color);
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        
+        .navbar-brand {
+            font-weight: 700;
+            color: white;
+        }
+        
+        .navbar-brand img {
+            height: 30px;
+            margin-right: 10px;
+        }
+        
+        .hero-section {
+            background: linear-gradient(135deg, var(--secondary-color), var(--primary-color));
+            color: white;
+            padding: 5rem 0;
+            margin-bottom: 3rem;
+        }
+        
+        .page-header {
+            background: linear-gradient(135deg, var(--secondary-color), var(--primary-color));
+            color: white;
+            padding: 3rem 0;
+            margin-bottom: 2rem;
+        }
+        
+        .card {
+            border: none;
+            border-radius: 10px;
+            box-shadow: 0 5px 15px rgba(0,0,0,0.05);
+            transition: all 0.3s ease;
+            margin-bottom: 20px;
+            overflow: hidden;
+        }
+        
+        .card:hover {
+            transform: translateY(-10px);
+            box-shadow: 0 15px 30px rgba(0,0,0,0.1);
+        }
+        
+        .card-img-top {
+            height: 180px;
+            object-fit: cover;
+            transition: transform 0.5s ease;
+        }
+        
+        .card:hover .card-img-top {
+            transform: scale(1.05);
+        }
+        
+        .card-body {
+            padding: 1.5rem;
+        }
+        
+        .card-title {
+            font-weight: 700;
+            margin-bottom: 0.75rem;
+        }
+        
+        .badge {
+            font-weight: 500;
+            padding: 5px 10px;
+            border-radius: 20px;
+        }
+        
+        .bg-primary {
+            background-color: var(--primary-color) !important;
+        }
+        
+        .bg-secondary {
+            background-color: var(--secondary-color) !important;
+        }
+        
+        .bg-accent {
+            background-color: var(--accent-color) !important;
+        }
+        
+        .btn-accent {
+            background-color: var(--accent-color);
+            border-color: var(--accent-color);
+            color: white;
+        }
+        
+        .btn-accent:hover {
+            background-color: #c0392b;
+            border-color: #c0392b;
+            color: white;
+        }
+        
+        .btn-outline-accent {
+            color: var(--accent-color);
+            border-color: var(--accent-color);
+        }
+        
+        .btn-outline-accent:hover {
+            background-color: var(--accent-color);
+            border-color: var(--accent-color);
+            color: white;
+        }
+        
+        .text-accent {
+            color: var(--accent-color) !important;
+        }
+        
+        .table-responsive {
+            border-radius: 10px;
+            overflow: hidden;
+            box-shadow: 0 5px 15px rgba(0,0,0,0.05);
+        }
+        
+        .table thead {
+            background-color: var(--primary-color);
+            color: white;
+        }
+        
+        .table th {
+            font-weight: 600;
+        }
+        
+        .status-badge {
+            padding: 5px 10px;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            font-weight: 500;
+        }
+        
+        .badge-active {
+            background-color: rgba(52, 152, 219, 0.2);
+            color: var(--primary-color);
+        }
+        
+        .badge-upcoming {
+            background-color: rgba(241, 196, 15, 0.2);
+            color: #f39c12;
+        }
+        
+        .badge-completed {
+            background-color: rgba(149, 165, 166, 0.2);
+            color: #7f8c8d;
+        }
+        
+        .filter-card {
+            border-radius: 10px;
+            box-shadow: 0 5px 15px rgba(0,0,0,0.05);
+            margin-bottom: 20px;
+        }
+        
+        .action-btn {
+            padding: 5px 10px;
+            font-size: 0.8rem;
+        }
+        
+        .pagination .page-item.active .page-link {
+            background-color: var(--primary-color);
+            border-color: var(--primary-color);
+        }
+        
+        .pagination .page-link {
+            color: var(--primary-color);
+        }
+        
+        .team-logo-sm {
+            width: 30px;
+            height: 30px;
+            object-fit: contain;
+        }
+        
+        .badge-pill {
+            border-radius: 10px;
+            padding: 5px 10px;
+            font-size: 0.8rem;
+            font-weight: 500;
+        }
+        
+        .match-score {
+            font-weight: bold;
+            font-size: 1.1rem;
+            background-color: #f8f9fa;
+            padding: 2px 8px;
+            border-radius: 5px;
+        }
+        
+        .live-badge {
+            animation: pulse 1.5s infinite;
+        }
+        
+        @keyframes pulse {
+            0% { opacity: 1; }
+            50% { opacity: 0.5; }
+            100% { opacity: 1; }
+        }
+        
+        .match-card {
+            border-left: 5px solid var(--primary-color);
+            transition: all 0.3s ease;
+        }
+        
+        .match-card:hover {
+            border-left-color: var(--accent-color);
+            transform: translateY(-3px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+        }
+        
+        .stats-card {
+            border-radius: 10px;
+            padding: 20px;
+            text-align: center;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            transition: all 0.3s ease;
+        }
+        
+        .stats-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 20px rgba(0,0,0,0.1);
+        }
+        
+        .stats-number {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+        }
+        
+        .stats-label {
+            font-size: 1rem;
+            color: #6c757d;
+        }
+        
+        footer {
+            background-color: var(--secondary-color);
+            color: white;
+            padding: 3rem 0;
+            margin-top: 3rem;
+        }
+        
+        .social-icon {
+            color: white;
+            font-size: 1.5rem;
+            margin-right: 15px;
+            transition: color 0.3s ease;
+        }
+        
+        .social-icon:hover {
+            color: var(--primary-color);
+        }
+        
+        /* Animation classes */
+        .fade-in {
+            animation: fadeIn 1s ease-in;
+        }
+        
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+        
+        .slide-up {
+            animation: slideUp 0.8s ease-out;
+        }
+        
+        @keyframes slideUp {
+            from { 
+                opacity: 0;
+                transform: translateY(50px);
+            }
+            to { 
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+        
+        /* Responsive adjustments */
+        @media (max-width: 768px) {
+            .hero-section {
+                padding: 3rem 0;
+            }
+            
+            .player-img {
+                height: 200px;
+            }
+        }
+    </style>
+    
+    @stack('styles')
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark sticky-top">
+        <div class="container">
+            <a class="navbar-brand" href="{{ route('fuma.index') }}">
+              <i class="fas fa-futbol me-2"></i> FUMA
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link {{ request()->routeIs('fuma.index') ? 'active' : '' }}" href="{{ route('fuma.index') }}">Home</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {{ request()->routeIs('fuma.tournaments*') ? 'active' : '' }}" href="{{ route('fuma.tournaments.index') }}">Tournaments</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {{ request()->routeIs('fuma.teams*') ? 'active' : '' }}" href="{{ route('fuma.teams.index') }}">Teams</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {{ request()->routeIs('fuma.matches*') ? 'active' : '' }}" href="{{ route('fuma.matches.index') }}">Matches</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {{ request()->routeIs('fuma.players*') ? 'active' : '' }}" href="{{ route('fuma.players.index') }}">Players</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('login') }}">
+                            <i class="fas fa-sign-in-alt me-1"></i> Login
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    @yield('content')
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <div class="row">
+                <div class="col-md-6">
+                    <h5 class="fw-bold mb-3">FUMA</h5>
+                    <p>The ultimate football tournament management system. Organize, manage, and track your tournaments with ease.</p>
+                    <div class="d-flex">
+                        <a href="#" class="social-icon"><i class="fab fa-facebook"></i></a>
+                        <a href="#" class="social-icon"><i class="fab fa-twitter"></i></a>
+                        <a href="#" class="social-icon"><i class="fab fa-instagram"></i></a>
+                        <a href="#" class="social-icon"><i class="fab fa-youtube"></i></a>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <h6 class="fw-bold mb-3">Quick Links</h6>
+                    <ul class="list-unstyled">
+                        <li><a href="{{ route('fuma.tournaments.index') }}" class="text-light text-decoration-none">Tournaments</a></li>
+                        <li><a href="{{ route('fuma.teams.index') }}" class="text-light text-decoration-none">Teams</a></li>
+                        <li><a href="{{ route('fuma.matches.index') }}" class="text-light text-decoration-none">Matches</a></li>
+                        <li><a href="{{ route('fuma.players.index') }}" class="text-light text-decoration-none">Players</a></li>
+                    </ul>
+                </div>
+                <div class="col-md-3">
+                    <h6 class="fw-bold mb-3">Contact</h6>
+                    <p class="mb-1"><i class="fas fa-envelope me-2"></i> info@fuma.com</p>
+                    <p class="mb-1"><i class="fas fa-phone me-2"></i> +1 234 567 8900</p>
+                    <p><i class="fas fa-map-marker-alt me-2"></i> Jakarta, Indonesia</p>
+                </div>
+            </div>
+            <hr class="my-4">
+            <div class="text-center">
+                <p>&copy; 2023 FUMA. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- Bootstrap 5 JS CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+    
+    @stack('scripts')
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,11 @@ use App\Enums\UserRole;
 use App\Http\Controllers\Console\UserController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\FumaController;
+use App\Http\Controllers\FumaTournamentController;
+use App\Http\Controllers\FumaTeamController;
+use App\Http\Controllers\FumaMatchController;
+use App\Http\Controllers\FumaPlayerController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -17,10 +22,38 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
+// FUMA Frontend Routes (Public)
+Route::get('/', [FumaController::class, 'index'])->name('fuma.index');
+
+Route::prefix('fuma')->name('fuma.')->group(function () {
+    // Tournaments
+    Route::get('/tournaments', [FumaTournamentController::class, 'index'])->name('tournaments.index');
+    Route::get('/tournaments/{tournament}', [FumaTournamentController::class, 'show'])->name('tournaments.show');
+    Route::get('/tournaments/create', [FumaTournamentController::class, 'create'])->name('tournaments.create');
+    Route::post('/tournaments', [FumaTournamentController::class, 'store'])->name('tournaments.store');
+    Route::delete('/tournaments/{tournament}', [FumaTournamentController::class, 'destroy'])->name('tournaments.destroy');
+
+    // Teams
+    Route::get('/teams', [FumaTeamController::class, 'index'])->name('teams.index');
+    Route::get('/teams/{team}', [FumaTeamController::class, 'show'])->name('teams.show');
+    Route::get('/teams/create', [FumaTeamController::class, 'create'])->name('teams.create');
+    Route::post('/teams', [FumaTeamController::class, 'store'])->name('teams.store');
+
+    // Matches
+    Route::get('/matches', [FumaMatchController::class, 'index'])->name('matches.index');
+    Route::get('/matches/{match}', [FumaMatchController::class, 'show'])->name('matches.show');
+    Route::get('/matches/create', [FumaMatchController::class, 'create'])->name('matches.create');
+    Route::post('/matches', [FumaMatchController::class, 'store'])->name('matches.store');
+    Route::patch('/matches/{match}/score', [FumaMatchController::class, 'updateScore'])->name('matches.updateScore');
+
+    // Players
+    Route::get('/players', [FumaPlayerController::class, 'index'])->name('players.index');
+    Route::get('/players/{player}', [FumaPlayerController::class, 'show'])->name('players.show');
+    Route::get('/players/create', [FumaPlayerController::class, 'create'])->name('players.create');
+    Route::post('/players', [FumaPlayerController::class, 'store'])->name('players.store');
 });
 
+// Admin Dashboard Routes
 Route::get('/dashboard', [DashboardController::class, 'index'])->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
Convert static FUMA HTML frontend to dynamic Blade templates with full backend integration and active CTAs.

---
<a href="https://cursor.com/background-agent?bcId=bc-343e0c07-4f12-4fd8-8941-80488ad99c2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-343e0c07-4f12-4fd8-8941-80488ad99c2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

